### PR TITLE
fix: add missing `return` from `storeOrderRecipient` [MX-1106]

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -6,7 +6,7 @@
  */
 
 const orders = require('./resources/orders');
-const orderRecipientFactory = require('./resources/order-recipients');
+const { orderRecipientFactory } = require('./resources/order-recipients');
 const config = require('./config');
 const api = require('./api');
 

--- a/lib/resources/order-recipients.js
+++ b/lib/resources/order-recipients.js
@@ -29,10 +29,10 @@ const createOrder = ({ contextId }) => async (params, callback) => {
  *
  * @returns {module:resources/orders~CreateFunc} `create` order function in context
  *
- * @private
+ * @protected
  */
 const storeOrderRecipient = ({ programCode }) => async member => {
-  await storeOrderRecipientSchema.validate(member).then(async () => {
+  return storeOrderRecipientSchema.validate(member).then(async () => {
     try {
       await setV5Token();
 
@@ -100,7 +100,7 @@ const orderRecipientFactory = (contextTypeName, contextId, programCode) => {
   };
 };
 
-module.exports = orderRecipientFactory;
+module.exports = { orderRecipientFactory, createOrder, storeOrderRecipient };
 
 /**
  * Default SDK configuration options type

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -2,7 +2,7 @@ const faker = require('faker');
 
 const context = require('../lib/context');
 const config = require('../lib/config');
-const orderRecipientFactory = require('../lib/resources/order-recipients');
+const { orderRecipientFactory } = require('../lib/resources/order-recipients');
 const orders = require('../lib/resources/orders');
 
 jest.mock('../lib/resources/order-recipients');


### PR DESCRIPTION
Completes [MX-1106](https://rewardops.atlassian.net/browse/MX-1106)

- refactor: export funcs from `order-recipients` module for testing