### PR TITLE
refactor: rename function names and arguments

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -67,10 +67,10 @@ function unlockToken() {
 const auth = {
   token: {},
 
-  getBaseUrl: options => `${urls.getApiBaseUrl(options)}/auth`,
+  getBaseUrl: config => `${urls.getApiBaseUrl(config)}/auth`,
 
-  getTokenUrl(options) {
-    return this.getBaseUrl(options) + TOKEN_PATH;
+  getTokenUrl(config) {
+    return this.getBaseUrl(config) + TOKEN_PATH;
   },
 
   getTokenPath() {
@@ -178,15 +178,15 @@ function requestToken(requestOptions, retryStrategy, callback) {
  *
  * @async
  *
- * @param {object} options Options object.
- * @param {string} options.clientId RewardOps API OAuth `client_id`.
- * @param {string} options.clientSecret RewardOps API OAuth `client_secret`.
- * @param {string} [options.timeout] Timeout for HTTP requests (used by [Request]{@link https://github.com/request/request}).
+ * @param {object} config Configuration object used by request function.
+ * @param {string} config.clientId RewardOps API OAuth `client_id`.
+ * @param {string} config.clientSecret RewardOps API OAuth `client_secret`.
+ * @param {string} [config.timeout] Timeout for HTTP requests (used by [Request]{@link https://github.com/request/request}).
  * @param {module:api~requestCallback} callback Callback that handles the response.
  *
  * @protected
  */
-const getToken = (options, callback) => {
+const getToken = (config, callback) => {
   /*
    * Calls to `RO.auth.getToken()` first check whether `RO.auth.tokenLocked()`
    * returns `true`. If it does, the callback passed to `RO.auth.getToken()` is
@@ -207,19 +207,19 @@ const getToken = (options, callback) => {
     maxAttempts: 3,
   };
 
-  if (!options.clientId || !options.clientSecret) {
+  if (!config.clientId || !config.clientSecret) {
     /*
      * Fire the callback with an error if the
-     * options doesn't have a clientId and clientSecret
+     * config doesn't have a clientId and clientSecret
      */
     const error = new Error();
 
     error.name = 'AuthenticationError';
     error.message = 'You must provide a ';
 
-    if (!options.clientId && !options.clientSecret) {
+    if (!config.clientId && !config.clientSecret) {
       error.message += 'clientId and clientSecret';
-    } else if (!options.clientId) {
+    } else if (!config.clientId) {
       error.message += 'clientId';
     } else {
       error.message += 'clientSecret';
@@ -238,18 +238,18 @@ const getToken = (options, callback) => {
      * Otherwise, request a new token
      */
     const requestOptions = {
-      url: options.piiServerUrl
-        ? auth.getTokenUrl({ apiVersion: 'v5', apiServerUrl: options.piiServerUrl })
-        : auth.getTokenUrl(options),
+      url: config.piiServerUrl
+        ? auth.getTokenUrl({ apiVersion: 'v5', apiServerUrl: config.piiServerUrl })
+        : auth.getTokenUrl(config),
       json: true,
       body: {
         grant_type: 'client_credentials',
       },
-      headers: generateBasicAuthToken(options.clientId, options.clientSecret),
+      headers: generateBasicAuthToken(config.clientId, config.clientSecret),
     };
 
-    if (options.timeout) {
-      requestOptions.timeout = options.timeout;
+    if (config.timeout) {
+      requestOptions.timeout = config.timeout;
     }
 
     requestToken(requestOptions, retryStrategy, callback);

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -57,7 +57,7 @@ function unlockToken() {
  *
  * @type {object}
  *
- * @property {{access_token: string, expires: Date}} token The current authorization token (retreived from the API).
+ * @property {{access_token: string, expires: Date}} token The current authorization token (retrieved from the API).
  * @property {Function} getBaseUrl Get the base URL for the RewardOps authorization token.
  * @property {Function} getTokenUrl Get the authorization token URL for the RewardOps API.
  * @property {Function} getTokenPath Get the value of `TOKEN_PATH`.
@@ -67,8 +67,22 @@ function unlockToken() {
 const auth = {
   token: {},
 
+  /**
+   * @type {Function}
+   *
+   * @param {{ apiVersion: string, apiServerUrl: string }} config Both params are used to build the url
+   *
+   * @returns {string} Returns the hostname plus the auth path
+   */
   getBaseUrl: config => `${urls.getApiBaseUrl(config)}/auth`,
 
+  /**
+   * @type {Function}
+   *
+   * @param {{ apiVersion: string, apiServerUrl: string }} config Both params are used to build the url
+   *
+   * @returns {string} Returns the complete token url
+   */
   getTokenUrl(config) {
     return this.getBaseUrl(config) + TOKEN_PATH;
   },

--- a/lib/resources/order-recipients.js
+++ b/lib/resources/order-recipients.js
@@ -8,7 +8,7 @@ const axios = require('axios');
 const { get } = require('lodash');
 
 const config = require('../config');
-const { setV5Token } = require('../utils/axios-helpers');
+const { setPiiToken } = require('../utils/axios-helpers');
 const { storeOrderRecipientSchema } = require('../schemas/store-order-recipient');
 
 const createOrder = ({ contextId }) => async (params, callback) => {
@@ -34,7 +34,7 @@ const createOrder = ({ contextId }) => async (params, callback) => {
 const storeOrderRecipient = ({ programCode }) => async member => {
   return storeOrderRecipientSchema.validate(member).then(async () => {
     try {
-      await setV5Token();
+      await setPiiToken();
 
       const {
         data: { result },
@@ -60,7 +60,7 @@ const storeOrderRecipient = ({ programCode }) => async member => {
  */
 const getOrderRecipient = ({ programCode }) => async (orderRecipientCode, callback) => {
   try {
-    await setV5Token();
+    await setPiiToken();
     const { data } = await axios.get(
       `${config.get('piiServerUrl')}/api/v5/programs/${programCode}/order_recipients/${orderRecipientCode}`
     );

--- a/lib/utils/axios-helpers.js
+++ b/lib/utils/axios-helpers.js
@@ -11,11 +11,11 @@ const config = require('../config');
  * promise will reject, otherwise it will resolve.
  *
  * @example
- * await setV5Token()
+ * await setPiiToken()
  *
  * @protected
  */
-const setV5Token = () =>
+const setPiiToken = () =>
   new Promise((resolve, reject) => {
     auth.getToken(
       { ...config.getAll(), apiVersion: 'v5', apiServerUrl: config.get('piiServerUrl') },
@@ -30,4 +30,4 @@ const setV5Token = () =>
     );
   });
 
-module.exports = { setV5Token };
+module.exports = { setPiiToken };

--- a/test/resources/v5/order-recipients.test.js
+++ b/test/resources/v5/order-recipients.test.js
@@ -72,7 +72,10 @@ describe('v5 order-recipients', () => {
       nock(mockPiiServerUrl).post(`/api/v5/programs/${mockProgramCode}/order_recipients`, member);
 
     const mockCreateOrderCall = () =>
-      nock(mockPiiServerUrl).post(`/api/v4/programs/${mockProgramId}/orders`, { amount: 100 });
+      nock(mockPiiServerUrl).post(`/api/v4/programs/${mockProgramId}/orders`, {
+        ...mockStoreOrderRecipientResponse,
+        amount: 100,
+      });
 
     describe('#storeOrderRecipient', () => {
       it('should return props from `storeOrderRecipient` when it receives a 200', async () => {

--- a/test/resources/v5/order-recipients.test.js
+++ b/test/resources/v5/order-recipients.test.js
@@ -3,10 +3,10 @@ const nock = require('nock');
 
 const RO = require('../../..');
 const orderRecipients = require('../../../lib/resources/order-recipients');
-const { setV5Token } = require('../../../lib/utils/axios-helpers');
+const { setPiiToken } = require('../../../lib/utils/axios-helpers');
 
 jest.mock('../../../lib/utils/axios-helpers');
-setV5Token.mockResolvedValue();
+setPiiToken.mockResolvedValue();
 
 const mockCallBack = jest.fn();
 const mockPiiServerUrl = faker.internet.url();
@@ -96,7 +96,7 @@ describe('v5 order-recipients', () => {
       });
 
       it('should return the error to the callback if an error occurs during auth', async () => {
-        setV5Token.mockRejectedValueOnce('testError');
+        setPiiToken.mockRejectedValueOnce('testError');
 
         await orderRecipient.create({ member }, mockCallBack);
 
@@ -139,7 +139,7 @@ describe('v5 order-recipients', () => {
 
   describe('#getOrderRecipient', () => {
     it('should return the error to the callback if an error occurs during auth', async () => {
-      setV5Token.mockRejectedValueOnce('testError');
+      setPiiToken.mockRejectedValueOnce('testError');
 
       await orderRecipient.getOrderRecipient(mockOrderRecipientCode, mockCallBack);
 

--- a/test/utils/axios-helper.test.js
+++ b/test/utils/axios-helper.test.js
@@ -4,7 +4,7 @@ const faker = require('faker');
 
 const config = require('../../lib/config');
 const auth = require('../../lib/auth');
-const { setV5Token } = require('../../lib/utils/axios-helpers');
+const { setPiiToken } = require('../../lib/utils/axios-helpers');
 
 const RoUrl = faker.internet.url();
 const piiUrl = faker.internet.url();
@@ -38,7 +38,7 @@ const mockV5AuthAPI = () =>
     })
     .basicAuth({ user: clientId, pass: clientSecret });
 
-describe('setV5Token', () => {
+describe('setPiiToken', () => {
   beforeEach(() => {
     axios.defaults.headers.common.Authorization = undefined;
     axios.defaults.tokenData = undefined;
@@ -58,7 +58,7 @@ describe('setV5Token', () => {
       created_at: Date.now(),
     });
 
-    await setV5Token();
+    await setPiiToken();
 
     expect(axios.defaults.headers.common.Authorization).toEqual(`Bearer ${expectedTestToken}`);
   });
@@ -66,6 +66,6 @@ describe('setV5Token', () => {
   it('should return the error from `auth.getToken` callback', async () => {
     jest.spyOn(auth, 'getToken').mockImplementation((_, callback) => callback('testError'));
 
-    await expect(setV5Token()).rejects.toMatch('testError');
+    await expect(setPiiToken()).rejects.toMatch('testError');
   });
 });


### PR DESCRIPTION
- Fix busted tests in order-recipients module

- Add JSDocs to base auth methods that take arguments
 
- Rename setV5Token func to setPiiToken
 
- Rename options in getToken to config