### PR TITLE
docs: move axios helpers into a module

### DIFF
--- a/lib/utils/axios-helpers.js
+++ b/lib/utils/axios-helpers.js
@@ -1,3 +1,9 @@
+/**
+ * Axios helpers
+ *
+ * @module utils/axios
+ * @copyright 2015–2020 RewardOps Inc.
+ */
 const axios = require('axios');
 
 const auth = require('../auth');
@@ -7,7 +13,7 @@ const config = require('../config');
  * Set axios' default auth header to OAuth Bearer Token from v5 RO API
  *
  * @async
- * @returns {Promise} If an error is returned from `auth.getToken` the
+ * @returns {Promise<void>} If an error is returned from `auth.getToken` the
  * promise will reject, otherwise it will resolve.
  *
  * @example


### PR DESCRIPTION
This moves it out of the apparent global scope in the docs.

## Test

- Generate the docs: `npm run build:docs`
- See that the axios helpers is now listed as a util module and `setPiiToken` is no longer list in the global scope