### PR TITLE
feat: allow caching of v4 and PII tokens

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -86,7 +86,7 @@ function apiCall(httpMethod, options, callback) {
              * since been updated, fire an "invalidateToken"
              * event, which deletes the existing token.
              */
-            emitter.emit('invalidateToken');
+            emitter.emit('invalidateToken', 'v4');
           }
 
           apiCall(httpMethod, options, callback);

--- a/lib/api.js
+++ b/lib/api.js
@@ -79,7 +79,7 @@ function apiCall(httpMethod, options, callback) {
 
           callback(err);
         } else if (response.statusCode === 401) {
-          if (token === auth.token.access_token) {
+          if (token === auth.tokens.v4.access_token) {
             /*
              * When the server responds to an API call
              * that the token is invalid, and the token hasn't

--- a/lib/api.js
+++ b/lib/api.js
@@ -79,6 +79,8 @@ function apiCall(httpMethod, options, callback) {
 
           callback(err);
         } else if (response.statusCode === 401) {
+          // TODO: update `v4` to accept `tokenId`
+          // when `api` module is used in order-recipients module.
           if (token === auth.tokens.v4.access_token) {
             /*
              * When the server responds to an API call

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -12,11 +12,14 @@ const urls = require('./urls');
 const { generateBasicAuthToken } = require('./utils/auth');
 
 /**
- * Token lock status
+ * Token lock status for v4 and PII
  *
  * @private
  */
-let tokenLocked = false;
+const tokenLockStatus = {
+  v4: false,
+  pii: false,
+};
 
 /**
  * URL path for the authorization token in the RewardOps API.
@@ -28,29 +31,35 @@ const TOKEN_PATH = '/token';
 /**
  * Get status of authorization token lock.
  *
+ * @param {string} tokenId Either `v4` or `pii`
+ *
  * @returns {boolean} Returns token lock status
  *
  * @private
  */
-const isTokenLocked = () => tokenLocked;
+const isTokenLocked = tokenId => tokenLockStatus[tokenId];
 
 /**
  * Lock authorization token.
  *
+ * @param {string} tokenId Either `v4` or `pii`
+ *
  * @private
  */
-function lockToken() {
-  tokenLocked = true;
-}
+const lockToken = tokenId => {
+  tokenLockStatus[tokenId] = true;
+};
 
 /**
  * Unlock authorization token.
  *
+ * @param {string} tokenId Either `v4` or `pii`
+ *
  * @private
  */
-function unlockToken() {
-  tokenLocked = false;
-}
+const unlockToken = tokenId => {
+  tokenLockStatus[tokenId] = false;
+};
 
 /**
  * Authorization token properties and actions object.
@@ -65,7 +74,10 @@ function unlockToken() {
  * @property {getToken} getToken Get authorization token.
  */
 const auth = {
-  token: {},
+  tokens: {
+    v4: {},
+    pii: {},
+  },
 
   /**
    * @type {Function}
@@ -91,9 +103,23 @@ const auth = {
     return TOKEN_PATH;
   },
 
-  invalidateToken: () => {
-    auth.token = {};
+  invalidateToken: tokenId => {
+    auth.tokens[tokenId] = {};
   },
+
+  tokenCue: {
+    v4: [],
+    pii: [],
+    addCallback: (tokenId, callback) => {
+      auth.tokenCue[tokenId].push(callback);
+    },
+    handleResolveRequest: tokenId => (...args) => {
+      auth.tokenCue[tokenId].forEach(cb => cb(...args));
+      auth.tokenCue[tokenId] = [];
+    },
+  },
+
+  timeoutError: undefined,
 };
 
 /**
@@ -103,15 +129,17 @@ const auth = {
  *
  * @async
  *
+ * @param {string} tokenId Either `v4` or `pii`
  * @param {object} requestOptions Options for a [Request]{@link https://github.com/request/request} POST call.
  * @param {{attempts: number, maxAttempts: number}} retryStrategy Request retry strategy options.
  * @param {module:api~requestCallback} callback Callback that handles the response.
  *
  * @protected
  */
-function requestToken(requestOptions, retryStrategy, callback) {
-  emitter.emit('lockToken');
-  emitter.once('unlockToken', callback);
+function requestToken(tokenId, requestOptions, retryStrategy, callback) {
+  emitter.emit('lockToken', tokenId);
+  emitter.once('resolveRequest', callback);
+  // emitter.on('unlockToken', unlockToken);
 
   retryStrategy.attempts += 1;
 
@@ -123,22 +151,35 @@ function requestToken(requestOptions, retryStrategy, callback) {
          * the max amount of counter.attempts has been
          * reached, pass the error to the callback
          */
-        emitter.emit('unlockToken', error);
+        console.log('GOT A TIMEOUT, RESOLVING', error);
+
+        auth.timeoutError = {
+          timeStamp: Date.now(),
+          error,
+        };
+
+        emitter.emit('resolveRequest', error);
+        emitter.emit('unlockToken', tokenId);
       } else {
         /*
          * If the request times out
          * and the max number of counter.attempts
          * hasn't been reached, try again
          */
-        emitter.removeListener('unlockToken', callback);
-        requestToken(requestOptions, retryStrategy, callback);
+        console.log('GOT A TIMEOUT, RETRY', retryStrategy.attempts);
+
+        emitter.removeListener('resolveRequest', callback);
+        requestToken(tokenId, requestOptions, retryStrategy, callback);
       }
     } else if (error) {
       /*
        * If there's a programmatic error,
        * fire the callback with the error
        */
-      emitter.emit('unlockToken', error);
+      console.log('UNKNOWN ERROR, RESOLVING', error);
+
+      emitter.emit('resolveRequest', error);
+      emitter.emit('unlockToken', tokenId);
     } else if (response.statusCode !== 200) {
       if (retryStrategy.attempts >= retryStrategy.maxAttempts) {
         /*
@@ -157,16 +198,20 @@ function requestToken(requestOptions, retryStrategy, callback) {
         }
 
         err.message += `(error ${response.statusCode})`;
+        console.log('AUTH ERROR, RESOLVING', err);
 
-        emitter.emit('unlockToken', err);
+        emitter.emit('resolveRequest', err);
+        emitter.emit('unlockToken', tokenId);
       } else {
         /*
          * If the server returns an error
          * and the max number of counter.attempts
          * hasn't been reached, try again
          */
-        emitter.removeListener('unlockToken', callback);
-        requestToken(requestOptions, retryStrategy, callback);
+        console.log('REMOVING LISTENER AND RETRYING');
+
+        emitter.removeListener('resolveRequest', callback);
+        requestToken(tokenId, requestOptions, retryStrategy, callback);
       }
     } else {
       /*
@@ -174,12 +219,16 @@ function requestToken(requestOptions, retryStrategy, callback) {
        * set auth.token and fire the
        * callback with the new token
        */
-      auth.token = {
+      auth.tokens[tokenId] = {
         access_token: body.access_token,
         expires: new Date((body.created_at + body.expires_in) * 1000),
       };
 
-      emitter.emit('unlockToken', null, auth.token.access_token);
+      // clear timeout error if present.
+      auth.timeoutError = undefined;
+
+      emitter.emit('resolveRequest', null, auth.tokens[tokenId].access_token);
+      emitter.emit('unlockToken', tokenId);
     }
   });
 }
@@ -200,7 +249,7 @@ function requestToken(requestOptions, retryStrategy, callback) {
  *
  * @protected
  */
-const getToken = (config, callback) => {
+const getToken = ({ tokenId = 'v4', test, ...config }, callback) => {
   /*
    * Calls to `RO.auth.getToken()` first check whether `RO.auth.tokenLocked()`
    * returns `true`. If it does, the callback passed to `RO.auth.getToken()` is
@@ -213,7 +262,7 @@ const getToken = (config, callback) => {
    * Then make a call to the oauth2 server for
    * a new token as usual.
    *
-   * All of this is to avoid a race condition where mutiple
+   * All of this is to avoid a race condition where multiple
    * calls for a new token happen at once.
    */
   const retryStrategy = {
@@ -240,13 +289,37 @@ const getToken = (config, callback) => {
     }
 
     callback(error);
-  } else if (auth.token && auth.token.access_token && auth.token.expires && auth.token.expires > new Date()) {
+  } else if (!['v4', 'pii'].includes(tokenId)) {
+    /*
+     * Fire the callback with an error if the
+     * tokenId is not `v4` or `pii`
+     */
+    const error = new Error();
+
+    error.name = 'ValidationError';
+    error.message = 'TokenId must be v4 or pii';
+
+    callback(error);
+  } else if (
+    auth.tokens[tokenId] &&
+    auth.tokens[tokenId].access_token &&
+    auth.tokens[tokenId].expires &&
+    auth.tokens[tokenId].expires > new Date()
+  ) {
     /*
      * If there's already a valid token, use it
      */
-    callback(null, auth.token.access_token);
-  } else if (isTokenLocked()) {
-    emitter.once('unlockToken', callback);
+    console.log('TOKEN IS VALID, RETURNING TOKEN');
+    callback(null, auth.tokens[tokenId].access_token);
+  } else if (isTokenLocked(tokenId) && !auth.timeoutError) {
+    /*
+     * Required for timeout mechanism and race condition
+     */
+    console.log('TOKEN IS LOCKED, ADDING CB TO QUEUE');
+
+    auth.tokenCue.addCallback(tokenId, callback);
+
+    emitter.once('resolveRequest', auth.tokenCue.handleResolveRequest(tokenId));
   } else {
     /*
      * Otherwise, request a new token
@@ -265,8 +338,10 @@ const getToken = (config, callback) => {
     if (config.timeout) {
       requestOptions.timeout = config.timeout;
     }
-
-    requestToken(requestOptions, retryStrategy, callback);
+    if (test === 'foo') {
+      console.log('CALLBACK 2, REQUESTING TOKEN');
+    }
+    requestToken(tokenId, requestOptions, retryStrategy, callback);
   }
 };
 

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -116,12 +116,26 @@ const auth = {
     },
 
     handleResolveRequest: tokenId => (...args) => {
-      auth.tokenQueue[tokenId].forEach(cb => cb(...args));
+      auth.tokenQueue[tokenId].forEach(callback => callback(...args));
       auth.tokenQueue[tokenId] = [];
     },
   },
 
-  timeoutError: undefined,
+  isTimeoutErrorPresent: tokenId => auth.timeoutError.has(tokenId),
+
+  addTimeoutError: (tokenId, error) => auth.timeoutError.set(tokenId, { timeStamp: Date.now(), error }),
+
+  clearTimeoutError: tokenId => auth.timeoutError.delete(tokenId),
+
+  /**
+   * @type {Map}
+   *
+   * On initialization, create a map that the helper functions can update through the Map API.
+   *
+   * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map
+   *
+   */
+  timeoutError: new Map(),
 };
 
 /**
@@ -151,11 +165,7 @@ function requestToken(tokenId, requestOptions, retryStrategy, callback) {
          * the max amount of counter.attempts has been
          * reached, pass the error to the callback
          */
-
-        auth.timeoutError = {
-          timeStamp: Date.now(),
-          error,
-        };
+        auth.addTimeoutError(tokenId, error);
 
         emitter.emit('resolveRequest', error);
         emitter.emit('unlockToken', tokenId);
@@ -220,7 +230,7 @@ function requestToken(tokenId, requestOptions, retryStrategy, callback) {
       };
 
       // clear timeout error if present.
-      auth.timeoutError = undefined;
+      auth.clearTimeoutError(tokenId);
 
       emitter.emit('resolveRequest', null, auth.tokens[tokenId].access_token);
       emitter.emit('unlockToken', tokenId);
@@ -307,7 +317,7 @@ const getToken = ({ tokenId = 'v4', ...config }, callback) => {
      */
 
     callback(null, auth.tokens[tokenId].access_token);
-  } else if (isTokenLocked(tokenId) && !auth.timeoutError) {
+  } else if (isTokenLocked(tokenId) && !auth.isTimeoutErrorPresent(tokenId)) {
     /*
      * If the token is locked and there is no timeout error
      * then add the callback to the queue to prevent race conditions.

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -107,15 +107,17 @@ const auth = {
     auth.tokens[tokenId] = {};
   },
 
-  tokenCue: {
+  tokenQueue: {
     v4: [],
     pii: [],
+
     addCallback: (tokenId, callback) => {
-      auth.tokenCue[tokenId].push(callback);
+      auth.tokenQueue[tokenId].push(callback);
     },
+
     handleResolveRequest: tokenId => (...args) => {
-      auth.tokenCue[tokenId].forEach(cb => cb(...args));
-      auth.tokenCue[tokenId] = [];
+      auth.tokenQueue[tokenId].forEach(cb => cb(...args));
+      auth.tokenQueue[tokenId] = [];
     },
   },
 
@@ -139,7 +141,6 @@ const auth = {
 function requestToken(tokenId, requestOptions, retryStrategy, callback) {
   emitter.emit('lockToken', tokenId);
   emitter.once('resolveRequest', callback);
-  // emitter.on('unlockToken', unlockToken);
 
   retryStrategy.attempts += 1;
 
@@ -151,7 +152,6 @@ function requestToken(tokenId, requestOptions, retryStrategy, callback) {
          * the max amount of counter.attempts has been
          * reached, pass the error to the callback
          */
-        console.log('GOT A TIMEOUT, RESOLVING', error);
 
         auth.timeoutError = {
           timeStamp: Date.now(),
@@ -166,7 +166,6 @@ function requestToken(tokenId, requestOptions, retryStrategy, callback) {
          * and the max number of counter.attempts
          * hasn't been reached, try again
          */
-        console.log('GOT A TIMEOUT, RETRY', retryStrategy.attempts);
 
         emitter.removeListener('resolveRequest', callback);
         requestToken(tokenId, requestOptions, retryStrategy, callback);
@@ -176,7 +175,6 @@ function requestToken(tokenId, requestOptions, retryStrategy, callback) {
        * If there's a programmatic error,
        * fire the callback with the error
        */
-      console.log('UNKNOWN ERROR, RESOLVING', error);
 
       emitter.emit('resolveRequest', error);
       emitter.emit('unlockToken', tokenId);
@@ -198,7 +196,6 @@ function requestToken(tokenId, requestOptions, retryStrategy, callback) {
         }
 
         err.message += `(error ${response.statusCode})`;
-        console.log('AUTH ERROR, RESOLVING', err);
 
         emitter.emit('resolveRequest', err);
         emitter.emit('unlockToken', tokenId);
@@ -208,7 +205,6 @@ function requestToken(tokenId, requestOptions, retryStrategy, callback) {
          * and the max number of counter.attempts
          * hasn't been reached, try again
          */
-        console.log('REMOVING LISTENER AND RETRYING');
 
         emitter.removeListener('resolveRequest', callback);
         requestToken(tokenId, requestOptions, retryStrategy, callback);
@@ -249,7 +245,7 @@ function requestToken(tokenId, requestOptions, retryStrategy, callback) {
  *
  * @protected
  */
-const getToken = ({ tokenId = 'v4', test, ...config }, callback) => {
+const getToken = ({ tokenId = 'v4', ...config }, callback) => {
   /*
    * Calls to `RO.auth.getToken()` first check whether `RO.auth.tokenLocked()`
    * returns `true`. If it does, the callback passed to `RO.auth.getToken()` is
@@ -309,17 +305,22 @@ const getToken = ({ tokenId = 'v4', test, ...config }, callback) => {
     /*
      * If there's already a valid token, use it
      */
-    console.log('TOKEN IS VALID, RETURNING TOKEN');
+
     callback(null, auth.tokens[tokenId].access_token);
   } else if (isTokenLocked(tokenId) && !auth.timeoutError) {
     /*
-     * Required for timeout mechanism and race condition
+     * If the token is locked and there is no timeout error
+     * then add the callback to the queue to prevent race conditions.
+     *
+     * Add a one time listener to empty the queue once the request
+     * has been resolved.
+     *
+     * If there is a timeout error, skip this step and allow a new request.
      */
-    console.log('TOKEN IS LOCKED, ADDING CB TO QUEUE');
 
-    auth.tokenCue.addCallback(tokenId, callback);
+    auth.tokenQueue.addCallback(tokenId, callback);
 
-    emitter.once('resolveRequest', auth.tokenCue.handleResolveRequest(tokenId));
+    emitter.once('resolveRequest', auth.tokenQueue.handleResolveRequest(tokenId));
   } else {
     /*
      * Otherwise, request a new token
@@ -338,9 +339,7 @@ const getToken = ({ tokenId = 'v4', test, ...config }, callback) => {
     if (config.timeout) {
       requestOptions.timeout = config.timeout;
     }
-    if (test === 'foo') {
-      console.log('CALLBACK 2, REQUESTING TOKEN');
-    }
+
     requestToken(tokenId, requestOptions, retryStrategy, callback);
   }
 };

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -306,6 +306,17 @@ const getToken = ({ tokenId = 'v4', ...config }, callback) => {
     error.message = 'TokenId must be v4 or pii';
 
     callback(error);
+  } else if (tokenId === 'pii' && !config.piiServerUrl) {
+    /*
+     * Fire the callback with an error if the
+     * tokenId is `pii` and piiServerUrl is not set.
+     */
+    const error = new Error();
+
+    error.name = 'ValidationError';
+    error.message = 'PII tokens require piiServerUrl to be set';
+
+    callback(error);
   } else if (
     auth.tokens[tokenId] &&
     auth.tokens[tokenId].access_token &&

--- a/lib/utils/axios-helpers.js
+++ b/lib/utils/axios-helpers.js
@@ -23,17 +23,14 @@ const config = require('../config');
  */
 const setPiiToken = () =>
   new Promise((resolve, reject) => {
-    auth.getToken(
-      { ...config.getAll(), apiVersion: 'v5', apiServerUrl: config.get('piiServerUrl') },
-      (error, token) => {
-        if (error) {
-          reject(error.toString());
-        }
-
-        axios.defaults.headers.common.Authorization = `Bearer ${token}`;
-        resolve();
+    auth.getToken({ ...config.getAll(), tokenId: 'pii' }, (error, token) => {
+      if (error) {
+        reject(error.toString());
       }
-    );
+
+      axios.defaults.headers.common.Authorization = `Bearer ${token}`;
+      resolve();
+    });
   });
 
 module.exports = { setPiiToken };

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -182,7 +182,7 @@ describe('api', () => {
 
   describe('get', () => {
     beforeAll(() => {
-      RO.auth.token = {};
+      RO.auth.tokens.v4 = {};
 
       fixtures();
     });

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -59,7 +59,7 @@ describe('api', () => {
           // Change auth.token after the
           // request has been made but before
           // sending the response
-          RO.auth.token = {
+          RO.auth.tokens.v4 = {
             access_token: secondToken,
             expires,
           };
@@ -88,7 +88,7 @@ describe('api', () => {
       RO.config.set('clientId', config.clientId);
       RO.config.set('clientSecret', config.clientSecret);
 
-      RO.auth.token = {
+      RO.auth.tokens.v4 = {
         access_token: firstToken,
         expires,
       };
@@ -154,7 +154,7 @@ describe('api', () => {
       RO.config.set('clientId', config.clientId);
       RO.config.set('clientSecret', config.clientSecret);
 
-      RO.auth.token = {
+      RO.auth.tokens.v4 = {
         access_token: badToken,
         expires,
       };
@@ -171,7 +171,7 @@ describe('api', () => {
           expect(authScope.isDone()).toEqual(true);
           expect(badScope.isDone()).toEqual(true);
           expect(goodScope.isDone()).toEqual(true);
-          expect(RO.auth.token.access_token).toEqual(goodToken);
+          expect(RO.auth.tokens.v4.access_token).toEqual(goodToken);
           expect(listenerWasFired).toEqual(true);
 
           done();
@@ -232,8 +232,8 @@ describe('api', () => {
           .query(params)
           .reply(200, { result: 'OK' });
 
-        RO.auth.token = { access_token: token, expires: new Date() };
-        RO.auth.token.expires.setHours(RO.auth.token.expires.getHours() + 2);
+        RO.auth.tokens.v4 = { access_token: token, expires: new Date() };
+        RO.auth.tokens.v4.expires.setHours(RO.auth.tokens.v4.expires.getHours() + 2);
 
         RO.api.get(
           {
@@ -261,7 +261,7 @@ describe('api', () => {
           clientSecret: 'abcdefg1234567',
         };
 
-        RO.auth.token = {};
+        RO.auth.tokens.v4 = {};
 
         RO.api.get(
           {

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -328,7 +328,7 @@ describe('RO.auth', () => {
             expect(error).toBeInstanceOf(Error);
             expect(error.message).toEqual('ETIMEDOUT');
 
-            RO.auth.getToken({ ...config, test: 'foo' }, (err, token) => {
+            RO.auth.getToken(config, (err, token) => {
               expect(err).toEqual(null);
 
               expect(token).toEqual(reply.access_token);
@@ -367,7 +367,7 @@ describe('RO.auth', () => {
             .once()
             .reply(200, reply);
 
-          RO.auth.tokens = {};
+          RO.auth.tokens.v4 = {};
 
           RO.auth.getToken(config, error => {
             expect(error).toBeInstanceOf(Error);
@@ -425,7 +425,7 @@ describe('RO.auth', () => {
           created_at: Math.round(+new Date() / 1000),
           expires_in: 7200,
         };
-        const n = 5;
+        const n = 5000;
         const arr = [];
 
         emitter.setMaxListeners(n + 1);

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -322,13 +322,10 @@ describe('RO.auth', () => {
           RO.auth.tokens.v4 = {};
 
           RO.auth.getToken(config, error => {
-            console.log('CALLBACK 1 RESULT', error);
             expect(error).toBeInstanceOf(Error);
             expect(error.message).toEqual('ETIMEDOUT');
 
             RO.auth.getToken({ ...config, test: 'foo' }, (err, token) => {
-              console.log('CALLBACK 2 RESULT', err);
-
               expect(err).toEqual(null);
 
               expect(token).toEqual(reply.access_token);

--- a/test/test-helpers/mock-config.js
+++ b/test/test-helpers/mock-config.js
@@ -21,7 +21,7 @@ const mockConfig = ({
   timeout = 20000,
   verbose = true,
   supportedLocales = undefined,
-}) => ({
+} = {}) => ({
   apiServerUrl,
   apiVersion,
   piiServerUrl,


### PR DESCRIPTION
https://rewardops.atlassian.net/browse/MX-1110

- add validation to `auth.getToken` to ensure `tokenId` param is valid
- create separate tokens for v4 endpoints (default) and PII endpoints
- the caller is responsible to ensure the `tokenId` is correct

**TODO**
- refactor the `api` module to be used in the `order-recipient` module.