### PR TITLE
refactor: misc cleanup [MX-1223]

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -126,7 +126,7 @@ module.exports = {
   setupFiles: ['./jest.setup.js'],
 
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
-  // setupFilesAfterEnv: [],
+  setupFilesAfterEnv: ['jest-mock-console/dist/setupTestFramework.js'],
 
   // The number of seconds after which a test is considered as slow and reported as such in the results.
   // slowTestThreshold: 5,

--- a/lib/schemas/store-order-recipient.js
+++ b/lib/schemas/store-order-recipient.js
@@ -10,7 +10,7 @@ const config = require('../config');
  *
  * @returns {boolean} True if value is a positive number or UUID, false otherwise
  *
- * @protected
+ * @private
  */
 const isNumberOrUuid = value =>
   every([

--- a/package-lock.json
+++ b/package-lock.json
@@ -7084,6 +7084,12 @@
         "@types/node": "*"
       }
     },
+    "jest-mock-console": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/jest-mock-console/-/jest-mock-console-1.0.1.tgz",
+      "integrity": "sha512-Bn+Of/cvz9LOEEeEg5IX5Lsf8D2BscXa3Zl5+vSVJl37yiT8gMAPPKfE09jJOwwu1zbagL11QTrH+L/Gn8udOg==",
+      "dev": true
+    },
     "jest-pnp-resolver": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -63,10 +63,11 @@
     "gh-pages": "^2.1.1",
     "husky": "^3.1.0",
     "jest": "^26.4.2",
+    "jest-mock-console": "^1.0.1",
     "jsdoc": "^3.6.3",
     "lint-staged": "^9.4.3",
-    "nock": "^9.6.1",
     "mockdate": "^3.0.2",
+    "nock": "^9.6.1",
     "prettier": "^1.19.1",
     "sinon": "^1.17.7",
     "standard-version": "^9.0.0"

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,4 +1,5 @@
 const faker = require('faker');
+const mockConsole = require('jest-mock-console');
 
 const config = require('../lib/config');
 const { getTestAccessToken } = require('../test/test-helpers/auth-helpers');
@@ -12,11 +13,11 @@ const validConfig = {
 };
 
 describe('config', () => {
-  describe('#init', () => {
-    beforeEach(() => {
-      config.reset();
-    });
+  afterEach(() => {
+    config.reset();
+  });
 
+  describe('#init', () => {
     test('an error is thrown if you call init more than once', () => {
       config.init(validConfig);
 
@@ -45,33 +46,28 @@ describe('config', () => {
 
   describe('#getAll', () => {
     it('should have the correct default values', () => {
-      config.reset();
-
       const actual = config.getAll();
 
       expect(actual).toStrictEqual(config.defaultConfig);
     });
   });
 
-  describe('get()', () => {
+  describe('#get', () => {
     it('should return a config value', () => {
-      config.reset();
-
       expect(config.get('apiVersion')).toEqual('v4');
       expect(config.get('verbose')).toEqual(false);
     });
   });
 
-  describe('set()', () => {
-    it('should set a config value', () => {
-      config.reset();
-
+  describe('#set', () => {
+    it('should set and return (then be able to get) a config value', () => {
       config.init(validConfig);
 
-      // Returns the new value
+      // TODO: remove this mock once we take the Console warning out out of the `config` module
+      mockConsole();
       expect(config.set('apiVersion', 'v1')).toEqual('v1');
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('deprecated'));
 
-      // The value was set correctly
       expect(config.get('apiVersion')).toEqual('v1');
     });
   });

--- a/test/test-helpers/mock-config.js
+++ b/test/test-helpers/mock-config.js
@@ -3,13 +3,23 @@ const faker = require('faker');
 const { getTestAccessToken } = require('./auth-helpers');
 
 /**
- * Test helper that returns a mock config object.
+ * Minimal mock {@link module:config~DefaultConfig} object.
  *
+ * @private
+ */
+const minimalMockConfig = {
+  clientId: getTestAccessToken(),
+  clientSecret: getTestAccessToken(),
+};
+
+/**
+ * Test helper that returns a complete mock config object.
  *
- * @param {{apiServerUrl: string, apiVersion: string, piiServerUrl: string, clientId: string, clientSecret: string, logToFile: boolean, timeout: number, verbose: boolean, supportedLocales: Array|undefined}} configOverrides Returns a complete config object with overrides and defaults.
- * @returns {object} Mock config object for tests.
+ * @param {module:config~DefaultConfig} configOverrides Returns a complete config object with overrides and defaults.
  *
- * @protected
+ * @returns {module:config~DefaultConfig} Mock config object.
+ *
+ * @private
  */
 const mockConfig = ({
   apiServerUrl = faker.internet.url(),
@@ -37,4 +47,4 @@ const mockConfig = ({
   quiet,
 });
 
-module.exports = { mockConfig };
+module.exports = { minimalMockConfig, mockConfig };


### PR DESCRIPTION
If applied, will:

- remove Console logging from test suite
- create a minimal mock configs for tests
- add missing prop tests for config.init method
- hide a validation schema helper from documentation generated output

## Testing

- Functionality should remain the same
- Tests should all pass