### PR TITLE
fix: refactor PII create to use `Orders#create` callback signature

### DIFF
--- a/lib/resources/order-recipients.js
+++ b/lib/resources/order-recipients.js
@@ -34,7 +34,7 @@ const createOrder = ({ contextId }) => async (params, callback) => {
 
     const response = await axios.post(url, params);
 
-    callback(null, response.data, response);
+    callback(null, response.data.result, response.data);
   } catch (error) {
     log(`API Error: ${prettyPrint(error)}`, { level: 'error' });
 

--- a/test/resources/v5/order-recipients.test.js
+++ b/test/resources/v5/order-recipients.test.js
@@ -147,11 +147,11 @@ describe('v5 order-recipients', () => {
           result: mockStoreOrderRecipientResponse,
         });
 
-        mockCreateOrderCall().reply(200, { result: 'ok' });
+        mockCreateOrderCall().reply(200, { result: 'testData' });
 
         await orderRecipient.create({ member, amount: 100 }, mockCallBack);
-
-        expect(mockCallBack).toBeCalledWith(null, { result: 'ok' }, expect.any(Object));
+        // PII create order should have the same callback signature as orders#create
+        expect(mockCallBack).toBeCalledWith(null, 'testData', { result: 'testData' });
       });
     });
   });


### PR DESCRIPTION
- there is a bug in the SDK where the PII and non PII order create have different callback signatures

relates to: https://github.com/rewardops/mx/pull/664