### PR TITLE
feat: redact PII from log output [MX-1262]

### DIFF
--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -99,19 +99,22 @@ const getLogLevel = () => {
 /**
  * RewardOps log format
  *
+ * @param {object} options Log format options
+ *
+ * @returns {string} Formatted log string
+ *
  * @private
  */
-const logFormat = printf(({ level, message = '', timestamp, meta = {} }) =>
+const logFormat = ({ level, message = '', timestamp, meta = {} }) =>
   [
     LOG_PREFIX,
     level.toUpperCase(),
     `[${timestamp}]`,
     formatMessage(message),
-    isEmpty(meta) ? '' : `\n\t${prettyPrint(meta)}`,
+    isEmpty(meta) ? '' : `\nMetadata:\t${prettyPrint(meta)}`,
   ]
     .join(' ')
-    .trim()
-);
+    .trim();
 
 /**
  * Winston logger configuration
@@ -120,7 +123,7 @@ const logFormat = printf(({ level, message = '', timestamp, meta = {} }) =>
  * @private
  */
 const logger = winston.createLogger({
-  format: combine(timestampFormatter(), logFormat),
+  format: combine(timestampFormatter(), printf(logFormat)),
   transports: [new winston.transports.Console({ level: getLogLevel() })],
 });
 

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -9,32 +9,82 @@
  */
 
 const winston = require('winston');
-const { isEmpty } = require('lodash');
+const { isEmpty, isPlainObject, isArray } = require('lodash');
+const redact = require('redact-secrets');
 
 const config = require('./../config');
 
 const { combine, timestamp: timestampFormatter, printf } = winston.format;
 
-/** RewardOps SDK log prefix */
+/**
+ * RewardOps SDK log prefix
+ *
+ * @private
+ */
 const LOG_PREFIX = 'RewardOps SDK';
 
 /**
- * Pretty print a JSON object
+ * Redacted message placeholder value
+ *
+ * @private
+ */
+const REDACTED_MESSAGE = '[REDACTED]';
+
+/**
+ * Reports whether a value is either an array or object, and therefore
+ * can be traversed as valid JSON (i.e. JSON-stringifiable).
+ *
+ * @param {*} value Any value
+ *
+ * @returns {boolean} Report of whether value can be traversed as JSON
+ *
+ * @private
+ */
+const isJSON = value => isPlainObject(value) || isArray(value);
+
+/**
+ * Pretty print a given value.
  *
  * @param {object|Array} json JSON object
  *
  * @returns {string} Prettier JSON string
  *
- * @protected
+ * @private
  */
 const prettyPrint = json => JSON.stringify(json, undefined, 2);
+
+/**
+ * Deeply iterate over an object and redact secret values by replacing
+ * them with a `REDACTED_MESSAGE` const string.
+ *
+ * @param {object} obj Object with potential secrets
+ *
+ * @returns {object} New object with secrets redacted
+ *
+ * @private
+ */
+const redactSecrets = obj => redact(REDACTED_MESSAGE).map(obj);
+
+/**
+ * Formats a message according to its type.
+ *
+ * If given a JSON-stringifiable object, it redacts any potential secrets
+ * and pretty prints; otherwise, it simply passes through the message.
+ *
+ * @param {*} message Log message
+ *
+ * @returns {string} Formatted message
+ *
+ * @private
+ */
+const formatMessage = message => (isJSON(message) ? prettyPrint(redactSecrets(message)) : message);
 
 /**
  * Get Winston log level based on SDK configuration.
  *
  * @returns {string} Log level
  *
- * @protected
+ * @private
  */
 const getLogLevel = () => {
   if (config.get('verbose')) {
@@ -46,12 +96,22 @@ const getLogLevel = () => {
   return 'info';
 };
 
-/** RewardOps log format */
-const logFormat = printf(({ level, message = '', timestamp, meta = {} }) => {
-  return [LOG_PREFIX, level.toUpperCase(), `[${timestamp}]`, message, isEmpty(meta) ? '' : `\n\t${prettyPrint(meta)}`]
+/**
+ * RewardOps log format
+ *
+ * @private
+ */
+const logFormat = printf(({ level, message = '', timestamp, meta = {} }) =>
+  [
+    LOG_PREFIX,
+    level.toUpperCase(),
+    `[${timestamp}]`,
+    formatMessage(message),
+    isEmpty(meta) ? '' : `\n\t${prettyPrint(meta)}`,
+  ]
     .join(' ')
-    .trim();
-});
+    .trim()
+);
 
 /**
  * Winston logger configuration
@@ -165,4 +225,14 @@ if (config.get('logToFile')) {
   setLogFilePath();
 }
 
-module.exports = { log, getLogLevel, setLogFilePath, prettyPrint, LOG_PREFIX };
+module.exports = {
+  log,
+  logFormat,
+  formatMessage,
+  getLogLevel,
+  setLogFilePath,
+  prettyPrint,
+  redactSecrets,
+  LOG_PREFIX,
+  REDACTED_MESSAGE,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -6211,6 +6211,11 @@
       "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
       "dev": true
     },
+    "is-secret": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-secret/-/is-secret-1.2.1.tgz",
+      "integrity": "sha512-VtBantcgKL2a64fDeCmD1JlkHToh3v0bVOhyJZ5aGTjxtCgrdNcjaC9GaaRFXi19gA4/pYFpnuyoscIgQCFSMQ=="
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -10089,6 +10094,15 @@
         "resolve": "^1.1.6"
       }
     },
+    "redact-secrets": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redact-secrets/-/redact-secrets-1.0.0.tgz",
+      "integrity": "sha1-YPHbVpJP6QogO6jMs5KDzbsNkHw=",
+      "requires": {
+        "is-secret": "^1.0.0",
+        "traverse": "^0.6.6"
+      }
+    },
     "redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -11536,6 +11550,11 @@
       "requires": {
         "punycode": "^2.1.1"
       }
+    },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
     },
     "trim-newlines": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
   "dependencies": {
     "axios": "^0.20.0",
     "lodash": "^4.17.15",
+    "redact-secrets": "^1.0.0",
     "request": "^2.88.0",
     "winston": "^3.3.3",
     "yup": "^0.29.3"


### PR DESCRIPTION
- Redacts PII from log messages
- Adds several private functions, with tests (mostly borrowed from the `mx` repo)
- Converts `logFormat` to a function, with tests
- Converts some JSDocs to `private` so they're not noise in the generated docs