### PR TITLE
fix: catch all 5XX and 4XX statusCodes

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -73,7 +73,7 @@ function apiCall(httpMethod, options, callback) {
 
       log(`Request: ${httpMethod} ${urls.getApiBaseUrl()}${options.path}`);
 
-      request(requestOptions, (err, { statusCode, headers } = {}, responseBody) => {
+      request(requestOptions, (err, { statusCode = 500, headers } = {}, responseBody) => {
         const meta = {
           request: requestOptions,
           response: {
@@ -107,6 +107,14 @@ function apiCall(httpMethod, options, callback) {
           log(`API Error: ${prettyPrint(responseBody.result.error.detail)}`, { level: 'error', meta });
 
           error = getError(responseBody.result.error.detail, statusCode, responseBody.result);
+          callback(error);
+        } else if (['5', '4'].includes(String(statusCode)[0])) {
+          /**
+           * Handle unexpected errors 5XX or 4XX (i.e. 504: GatewayTimeout)
+           */
+          log(`API Error: Unknown cause, status ${statusCode}`, { level: 'error', meta });
+
+          error = getError(null, statusCode, null);
           callback(error);
         } else {
           log(`Success: ${statusCode} ${urls.getApiBaseUrl()}${options.path}`);

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -29,6 +29,7 @@ describe('api', () => {
       .get('/timeout-error')
       .once()
       .reply(504);
+      
     return new Promise(done => {
       RO.api.get(
         {


### PR DESCRIPTION
`Request: GET https://uat-api.rewardops.io/api/v4/programs/384/orders/summary` is timing out on UAT-API, causing the node sever to crash locally.

**BEFORE**
***
![Screen Shot 2020-11-02 at 12 13 50 PM](https://user-images.githubusercontent.com/24878037/97898100-674be080-1d05-11eb-9661-f95a00234f08.png)
***

Added a catch all for any status matching 5XX and 4XX

**AFTER**
***
![Screen Shot 2020-11-02 at 12 15 12 PM](https://user-images.githubusercontent.com/24878037/97898268-a24e1400-1d05-11eb-95db-03f3fbb71978.png)
