### PR TITLE
fix: create instance of axios for PII calls MX-1388

### DIFF
--- a/lib/resources/order-recipients.js
+++ b/lib/resources/order-recipients.js
@@ -14,6 +14,8 @@ const { setPiiToken } = require('../utils/axios-helpers');
 const { SDKError } = require('../utils/error');
 const { log, prettyPrint } = require('../utils/logger');
 
+const ordersClient = axios.create();
+
 /**
  * Higher order function for creating an order in context. Same as {@link module:resources/orders~createOrder}
  *
@@ -34,7 +36,7 @@ const createOrder = ({ contextId }) => async (params, callback) => {
 
     log(`Request: POST ${url}\nPayload: ${prettyPrint(params)}`);
 
-    const response = await axios.post(url, params);
+    const response = await ordersClient.post(url, params);
 
     callback(null, response.data.result, response.data);
   } catch (error) {
@@ -72,7 +74,7 @@ const createOrder = ({ contextId }) => async (params, callback) => {
 const storeOrderRecipient = ({ programCode }) => async member => {
   return storeOrderRecipientSchema.validate(member).then(async () => {
     try {
-      await setPiiToken();
+      await setPiiToken(ordersClient);
 
       const url = `${config.get('piiServerUrl')}/api/v5/programs/${programCode}/order_recipients`;
 
@@ -80,7 +82,7 @@ const storeOrderRecipient = ({ programCode }) => async member => {
 
       const {
         data: { result },
-      } = await axios.post(url, member);
+      } = await ordersClient.post(url, member);
       return result;
     } catch (error) {
       log(`API Error: ${prettyPrint(error)}`, { level: 'error' });
@@ -166,8 +168,9 @@ const createOrderWithPiiStorage = orderContext => async ({ member, ...createOrde
  */
 const getOrderRecipient = ({ programCode }) => async (orderRecipientCode, callback) => {
   try {
-    await setPiiToken();
-    const { data } = await axios.get(
+    await setPiiToken(ordersClient);
+
+    const { data } = await ordersClient.get(
       `${config.get('piiServerUrl')}/api/v5/programs/${programCode}/order_recipients/${orderRecipientCode}`
     );
     callback(null, data.result, data);

--- a/lib/utils/axios-helpers.js
+++ b/lib/utils/axios-helpers.js
@@ -13,6 +13,8 @@ const config = require('../config');
  * Set axios' default auth header to OAuth Bearer Token from v5 RO API
  *
  * @async
+ *
+ * @param {axios.AxiosInstance<void>} client Avoids polluting the global axios object.
  * @returns {Promise<void>} If an error is returned from `auth.getToken` the
  * promise will reject, otherwise it will resolve.
  *
@@ -21,7 +23,7 @@ const config = require('../config');
  *
  * @protected
  */
-const setPiiToken = () =>
+const setPiiToken = client =>
   new Promise((resolve, reject) => {
     auth.getToken(
       { ...config.getAll(), apiVersion: 'v5', apiServerUrl: config.get('piiServerUrl') },
@@ -30,7 +32,7 @@ const setPiiToken = () =>
           reject(error.toString());
         }
 
-        axios.defaults.headers.common.Authorization = `Bearer ${token}`;
+        client.defaults.headers.common.Authorization = `Bearer ${token}`;
         resolve();
       }
     );

--- a/lib/utils/axios-helpers.js
+++ b/lib/utils/axios-helpers.js
@@ -19,7 +19,7 @@ const config = require('../config');
  * promise will reject, otherwise it will resolve.
  *
  * @example
- * await setPiiToken()
+ * await setPiiToken(client)
  *
  * @protected
  */

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -29,7 +29,7 @@ describe('api', () => {
       .get('/timeout-error')
       .once()
       .reply(504);
-      
+
     return new Promise(done => {
       RO.api.get(
         {

--- a/test/utils/axios-helper.test.js
+++ b/test/utils/axios-helper.test.js
@@ -48,6 +48,8 @@ describe('setPiiToken', () => {
     await setPiiToken(ordersClient);
 
     expect(ordersClient.defaults.headers.common.Authorization).toEqual(`Bearer ${expectedTestToken}`);
+    // assert that the global defaults are not mutated.
+    expect(axios.defaults.headers.common.Authorization).toEqual(undefined);
   });
 
   it('should return the error from `auth.getToken` callback', async () => {

--- a/test/utils/axios-helper.test.js
+++ b/test/utils/axios-helper.test.js
@@ -30,14 +30,10 @@ const mockV5AuthAPI = () =>
     .basicAuth({ user: clientId, pass: clientSecret });
 
 describe('setPiiToken', () => {
+  let ordersClient;
+
   beforeEach(() => {
-    axios.defaults.headers.common.Authorization = undefined;
-    axios.defaults.tokenData = undefined;
-  });
-  // clean up after all tests in this file have run.
-  afterAll(() => {
-    axios.defaults.headers.common.Authorization = undefined;
-    axios.defaults.tokenData = undefined;
+    ordersClient = axios.create();
   });
 
   it('should set the accessToken', async () => {
@@ -49,14 +45,14 @@ describe('setPiiToken', () => {
       created_at: Date.now(),
     });
 
-    await setPiiToken();
+    await setPiiToken(ordersClient);
 
-    expect(axios.defaults.headers.common.Authorization).toEqual(`Bearer ${expectedTestToken}`);
+    expect(ordersClient.defaults.headers.common.Authorization).toEqual(`Bearer ${expectedTestToken}`);
   });
 
   it('should return the error from `auth.getToken` callback', async () => {
-    jest.spyOn(auth, 'getToken').mockImplementation((_, callback) => callback('testError'));
+    jest.spyOn(auth, 'getToken').mockImplementationOnce((_, callback) => callback('testError'));
 
-    await expect(setPiiToken()).rejects.toMatch('testError');
+    await expect(setPiiToken(ordersClient)).rejects.toMatch('testError');
   });
 });


### PR DESCRIPTION
My suspicion is that pollution of the global axios object is leading to a bug where MX is forwarding a PII token to zendesk b/c MX and the node SDK are using the same axios object.