### PR TITLE
🔥 Remove URL validation because it does not support localhost

### DIFF
--- a/lib/schemas/config.js
+++ b/lib/schemas/config.js
@@ -1,17 +1,14 @@
 const yup = require('yup');
 
+// Add URL once this is resolved: https://github.com/jquense/yup/issues/800
 const configSchema = yup.object().shape({
-  apiServerUrl: yup
-    .string()
-    .url()
-    .nullable(),
+  apiServerUrl: yup.string().nullable(),
   apiVersion: yup
     .string()
     .oneOf(['v3', 'v4', 'v5'])
     .required(),
   piiServerUrl: yup
     .string()
-    .url()
     .nullable()
     .default(null),
   clientId: yup.string().required(),


### PR DESCRIPTION
Currently to go around this issue in the MX app we are locally modifying the app config to this : 


```js
const setRoSdkConfig = (config: Config) => {
  const rewardOpsConfig = config.get('rewardOps');
  const loggingConfig = config.get('logging');

  RO.config.init({
    apiVersion: rewardOpsConfig.apiVersion,
    clientId: rewardOpsConfig.clientId,
    clientSecret: rewardOpsConfig.clientSecret,
    logToFile: loggingConfig.logToFile,
    logFilePath: path.join(loggingConfig?.logFileDir ?? '', 'sdk.log'),
    verbose: loggingConfig.verbose,
    piiServerUrl: rewardOpsConfig.piiServerUrl,
    supportedLocales: rewardOpsConfig.supportedLocales,
  });
  RO.config.set('apiServerUrl', rewardOpsConfig.apiServerUrl);
};
```

And using `set` defeats the purpose of introducing `init` 