### PR TITLE
feat: add request object to the api callback signature

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -177,4 +177,5 @@ module.exports = api;
  * @param {(Error|null)} error Either an `Error` object or `null` if there's no error
  * @param {object} responseBody The 'result' object from the API response body
  * @param {object} response The full body of the response from the API. This includes pagination details, if present
+ * @param {object} [req] The full request object from the request library.
  */

--- a/lib/api.js
+++ b/lib/api.js
@@ -73,7 +73,7 @@ function apiCall(httpMethod, options, callback) {
 
       log(`Request: ${httpMethod} ${urls.getApiBaseUrl()}${options.path}`);
 
-      request(requestOptions, (err, { statusCode = 500, headers, req } = {}, responseBody) => {
+      request(requestOptions, (err, { statusCode = 500, headers, request: req } = {}, responseBody) => {
         const meta = {
           request: requestOptions,
           response: {

--- a/lib/api.js
+++ b/lib/api.js
@@ -73,7 +73,7 @@ function apiCall(httpMethod, options, callback) {
 
       log(`Request: ${httpMethod} ${urls.getApiBaseUrl()}${options.path}`);
 
-      request(requestOptions, (err, { statusCode = 500, headers } = {}, responseBody) => {
+      request(requestOptions, (err, { statusCode = 500, headers, req } = {}, responseBody) => {
         const meta = {
           request: requestOptions,
           response: {
@@ -119,7 +119,7 @@ function apiCall(httpMethod, options, callback) {
         } else {
           log(`Success: ${statusCode} ${urls.getApiBaseUrl()}${options.path}`);
 
-          callback(null, responseBody.result, responseBody);
+          callback(null, responseBody.result, responseBody, req);
         }
       });
     }

--- a/lib/resources/order-recipients.js
+++ b/lib/resources/order-recipients.js
@@ -16,6 +16,7 @@ const { log, prettyPrint } = require('../utils/logger');
 
 const ordersClient = axios.create();
 
+// TODO: add request object to callback when errors occur (for API module as well).
 /**
  * Higher order function for creating an order in context. Same as {@link module:resources/orders~createOrder}
  *
@@ -36,9 +37,9 @@ const createOrder = ({ contextId }) => async (params, callback) => {
 
     log(`Request: POST ${url}\nPayload: ${prettyPrint(params)}`);
 
-    const response = await ordersClient.post(url, params);
+    const { data, request } = await ordersClient.post(url, params);
 
-    callback(null, response.data.result, response.data);
+    callback(null, data.result, data, request);
   } catch (error) {
     log(`API Error: ${prettyPrint(error)}`, { level: 'error' });
 
@@ -170,10 +171,10 @@ const getOrderRecipient = ({ programCode }) => async (orderRecipientCode, callba
   try {
     await setPiiToken(ordersClient);
 
-    const { data } = await ordersClient.get(
+    const { data, request } = await ordersClient.get(
       `${config.get('piiServerUrl')}/api/v5/programs/${programCode}/order_recipients/${orderRecipientCode}`
     );
-    callback(null, data.result, data);
+    callback(null, data.result, data, request);
   } catch (error) {
     log(`API Error: ${prettyPrint(error)}`, { level: 'error' });
 

--- a/lib/resources/order-recipients.js
+++ b/lib/resources/order-recipients.js
@@ -16,7 +16,7 @@ const { log, prettyPrint } = require('../utils/logger');
 
 const ordersClient = axios.create();
 
-// TODO: add request object to callback when errors occur (for API module as well).
+// TODO: add request object to callback when errors occur (for API module as well see https://rewardops.atlassian.net/browse/MX-1559)
 /**
  * Higher order function for creating an order in context. Same as {@link module:resources/orders~createOrder}
  *

--- a/lib/resources/orders.js
+++ b/lib/resources/orders.js
@@ -100,9 +100,7 @@ const getAllOrders = orderContext => {
 
     options.params.member_id = memberId;
 
-    api.get(options, (error, data, response) => {
-      callback(error, data, response);
-    });
+    api.get(options, callback);
   };
 };
 

--- a/lib/resources/orders.js
+++ b/lib/resources/orders.js
@@ -39,9 +39,7 @@ const getOrderSummary = orderContext => {
 
     options.params = params;
 
-    api.get(options, (err, data, response) => {
-      callback(err, data, response);
-    });
+    api.get(options, callback);
   };
 };
 
@@ -157,9 +155,7 @@ const getOrder = orderContext => {
       callback = params;
     }
 
-    api.get(options, (error, data, response) => {
-      callback(error, data, response);
-    });
+    api.get(options, callback);
   };
 };
 
@@ -243,9 +239,7 @@ const createOrder = orderContext => {
       params,
     };
 
-    api.post(options, (err, data, response) => {
-      callback(err, data, response);
-    });
+    api.post(options, callback);
   };
 };
 
@@ -326,9 +320,7 @@ const updateOrder = orderContext => {
       params,
     };
 
-    api.patch(options, (err, data, response) => {
-      callback(err, data, response);
-    });
+    api.patch(options, callback);
   };
 };
 
@@ -395,9 +387,7 @@ const updateOrderItemsInContext = orderContext => {
       params,
     };
 
-    api.patch(options, (err, data, response) => {
-      callback(err, data, response);
-    });
+    api.patch(options, callback);
   };
 };
 

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -39,7 +39,13 @@ describe('api', () => {
         (error, _, __, request) => {
           expect(error).toEqual(null);
 
-          expect(request).toEqual(expect.objectContaining({ headers: expect.any(Object) }));
+          expect(request).toEqual(
+            expect.objectContaining({
+              headers: expect.any(Object),
+              method: 'GET',
+              uri: expect.any(Object),
+            })
+          );
 
           done();
         }

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -22,6 +22,31 @@ describe('api', () => {
     expect(typeof RO.api).toBe('object');
   });
 
+  it('should pass the request object to the callback', () => {
+    jest.spyOn(auth, 'getToken').mockImplementationOnce((_, callback) => callback(null, 'testToken'));
+
+    nock(RO.urls.getApiBaseUrl())
+      .get('/')
+      .once()
+      .reply(200, { result: 'foo' });
+
+    return new Promise(done => {
+      RO.api.get(
+        {
+          path: '/',
+          config: {},
+        },
+        (error, _, __, request) => {
+          expect(error).toEqual(null);
+
+          expect(request).toEqual(expect.objectContaining({ headers: expect.any(Object) }));
+
+          done();
+        }
+      );
+    });
+  });
+
   it('should handle 5XX responses', () => {
     jest.spyOn(auth, 'getToken').mockImplementationOnce((_, callback) => callback(null, 'testToken'));
 

--- a/test/resources/v5/order-recipients.test.js
+++ b/test/resources/v5/order-recipients.test.js
@@ -168,7 +168,12 @@ describe('v5 order-recipients', () => {
         expect(createOrderCall.isDone()).toBe(true);
 
         // NOTE: PII create order should have the same callback signature as orders#create
-        expect(mockCallBack).toBeCalledWith(null, 'testData', { result: 'testData' });
+        expect(mockCallBack).toBeCalledWith(
+          null,
+          'testData',
+          { result: 'testData' },
+          expect.objectContaining({ headers: expect.any(Object) })
+        );
       });
     });
   });
@@ -201,7 +206,12 @@ describe('v5 order-recipients', () => {
       await orderRecipient.getOrderRecipient(mockOrderRecipientCode, mockCallBack);
 
       expect(call.isDone()).toBe(true);
-      expect(mockCallBack).toHaveBeenCalledWith(null, 42, { foo: 'bar', result: 42 });
+      expect(mockCallBack).toHaveBeenCalledWith(
+        null,
+        42,
+        { foo: 'bar', result: 42 },
+        expect.objectContaining({ headers: expect.any(Object) })
+      );
     });
   });
 });


### PR DESCRIPTION
[MX-1552](https://rewardops.atlassian.net/browse/MX-1552)

To complete the Data Dog (DD) tracer ID POC, we need the `api` module to return the `request` object that contains metadata that the DD middleware injects into each request.