### PR TITLE
fix: adjust order cancel schema

### DIFF
--- a/lib/schemas/cancel-order.js
+++ b/lib/schemas/cancel-order.js
@@ -14,7 +14,7 @@ const cancelOrderSchema = yup.object().shape({
     yup.object({
       supplier_id: yup.string().required(),
       fulfillment: yup.object().shape({
-        member_paid: amountAndCurrencyCode,
+        member_paid: yup.array().of(yup.object({ amount: yup.number(), currency_code: yup.string() })),
         program_cost: amountAndCurrencyCode,
       }),
       order_items: yup

--- a/test/resources/v4/program-orders.test.js
+++ b/test/resources/v4/program-orders.test.js
@@ -609,12 +609,7 @@ describe('RO.program.orders', () => {
             {
               supplier_id: 0,
               fulfillment: {
-                member_paid: [
-                  {
-                    amount: 0,
-                    currency_code: 'CAD',
-                  },
-                ],
+                member_paid: [],
                 program_cost: [
                   {
                     amount: 0,
@@ -624,19 +619,19 @@ describe('RO.program.orders', () => {
               },
               order_items: [
                 {
-                  order_item_external_id: '',
                   member_paid: [
                     {
-                      amount: 0,
+                      amount: '0',
                       currency_code: 'CAD',
                     },
                   ],
                   program_cost: [
                     {
-                      amount: 0,
+                      amount: '0',
                       currency_code: 'CAD',
                     },
                   ],
+                  order_item_external_id: '',
                 },
               ],
             },


### PR DESCRIPTION
[MX-1339](https://rewardops.atlassian.net/browse/MX-1339)

Update the schema to allow `member_paid` on fulfillment to be empty.