### PR TITLE
refactor(log): unify log format with mx-apps

### DIFF
--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -160,10 +160,9 @@ const getLogLevel = () => {
  */
 const logFormat = ({ level, message = '', timestamp, meta = {} }) =>
   [
-    LOG_PREFIX,
-    level.toUpperCase(),
     `[${timestamp}]`,
-    formatMessage(message),
+    `[${LOG_PREFIX} ${level.toUpperCase()}]`,
+    `[${formatMessage(message)}]`,
     isEmpty(meta) ? '' : `\nMetadata:\t${prettyPrint(meta)}`,
   ]
     .join(' ')

--- a/test/utils/logger.test.js
+++ b/test/utils/logger.test.js
@@ -231,13 +231,22 @@ describe('#processLogData', () => {
 describe('#logFormat', () => {
   const mockTimestamp = new Date().toISOString();
   const mockLogLevel = faker.random.arrayElement(['error', 'warn', 'info', 'debug', 'verbose']);
+  const mockMessage = faker.lorem.sentence();
+
+  it('logs with correct format', () => {
+    const formattedLog = logFormat({ level: mockLogLevel, message: mockMessage, timestamp: mockTimestamp });
+
+    const expectedLog = `[${mockTimestamp}] [${LOG_PREFIX} ${mockLogLevel.toUpperCase()}] [${mockMessage}]`;
+
+    expect(formattedLog).toEqual(expectedLog);
+  });
 
   it('logs SDK prefix, timestamp, and log level', () => {
     expect.assertions(4);
 
-    const formattedLog = logFormat({ level: mockLogLevel, message: 'foobar', timestamp: mockTimestamp });
+    const formattedLog = logFormat({ level: mockLogLevel, message: mockMessage, timestamp: mockTimestamp });
 
-    const EXPECTED_SUBSTRINGS = [LOG_PREFIX, mockTimestamp, mockLogLevel.toUpperCase(), 'foobar'];
+    const EXPECTED_SUBSTRINGS = [LOG_PREFIX, mockTimestamp, mockLogLevel.toUpperCase(), mockMessage];
     EXPECTED_SUBSTRINGS.forEach(substring => {
       expect(formattedLog).toEqual(expect.stringContaining(substring));
     });

--- a/test/utils/logger.test.js
+++ b/test/utils/logger.test.js
@@ -233,14 +233,6 @@ describe('#logFormat', () => {
   const mockLogLevel = faker.random.arrayElement(['error', 'warn', 'info', 'debug', 'verbose']);
   const mockMessage = faker.lorem.sentence();
 
-  it('logs with correct format', () => {
-    const formattedLog = logFormat({ level: mockLogLevel, message: mockMessage, timestamp: mockTimestamp });
-
-    const expectedLog = `[${mockTimestamp}] [${LOG_PREFIX} ${mockLogLevel.toUpperCase()}] [${mockMessage}]`;
-
-    expect(formattedLog).toEqual(expectedLog);
-  });
-
   it('logs SDK prefix, timestamp, and log level', () => {
     expect.assertions(4);
 
@@ -301,6 +293,14 @@ describe('#logFormat', () => {
     EXPECTED_SUBSTRINGS.forEach(substring => {
       expect(formattedLog).toEqual(expect.stringContaining(substring));
     });
+  });
+
+  it('logs inputs with correct format', () => {
+    const formattedLog = logFormat({ level: mockLogLevel, message: mockMessage, timestamp: mockTimestamp });
+
+    const expectedLog = `[${mockTimestamp}] [${LOG_PREFIX} ${mockLogLevel.toUpperCase()}] [${mockMessage}]`;
+
+    expect(formattedLog).toEqual(expectedLog);
   });
 });
 


### PR DESCRIPTION
[MX-1423](https://rewardops.atlassian.net/browse/MX-1423)

Minor change on log format to match requirement in ticket.