### PR TITLE
chore: fix logging config bug, add `silent` config option [MX-3005]

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,6 +17,7 @@ declare module '@rewardops/sdk-node' {
     timeout?: number;
     verbose: boolean;
     quiet?: boolean;
+    silent?: boolean;
   };
 
   interface RequestCallback<Data = unknown, Res = unknown> extends Function {

--- a/lib/config.js
+++ b/lib/config.js
@@ -170,7 +170,7 @@ module.exports = {
  * @property {number} [timeout=20000] Timeout for HTTP requests (used by {@link https://github.com/request/request Request library}).
  * @property {string} [logFilePath='<parent dir>/logs/ro.log'] Path for log output file.
  * @property {boolean} [logToFile=false] If `true` and if {@link config.verbose} is `true`, saves log messages to file.
- * @property {boolean} [silent=false] Run SDK with only critical logging.
+ * @property {boolean} [silent=false] Suppress console logging.
  * @property {boolean} [verbose=false] Run SDK with verbose logging. NOTE: Superseded by `silent` if both are `true`.
  * @property {boolean} [quiet=false] Run SDK with minimal logging. NOTE: Superseded by `verbose` if both are `true`.
  */

--- a/lib/config.js
+++ b/lib/config.js
@@ -93,7 +93,7 @@ const set = (key, value) => {
 /**
  * Boolean that indicates whether the config module has been initialized
  *
- * @protected
+ * @private
  */
 let configInitialized = false;
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -31,6 +31,7 @@ const defaultConfig = {
   logToFile: false,
   verbose: false,
   quiet: false,
+  silent: false,
 };
 
 /**
@@ -169,6 +170,7 @@ module.exports = {
  * @property {number} [timeout=20000] Timeout for HTTP requests (used by {@link https://github.com/request/request Request library}).
  * @property {string} [logFilePath='<parent dir>/logs/ro.log'] Path for log output file.
  * @property {boolean} [logToFile=false] If `true` and if {@link config.verbose} is `true`, saves log messages to file.
- * @property {boolean} [verbose=false] Run SDK with verbose logging (as well as in optional file).
- * @property {boolean} [quiet=false] Run SDK with minimal logging(as well as in optional file). NOTE: Superceded by `verbose` if both are `true`.
+ * @property {boolean} [silent=false] Run SDK with only critical logging.
+ * @property {boolean} [verbose=false] Run SDK with verbose logging. NOTE: Superseded by `silent` if both are `true`.
+ * @property {boolean} [quiet=false] Run SDK with minimal logging. NOTE: Superseded by `verbose` if both are `true`.
  */

--- a/lib/config.js
+++ b/lib/config.js
@@ -134,6 +134,13 @@ const init = initialConfig => {
   return Object.freeze(config);
 };
 
+/**
+ * Check whether the library config module has been initialized
+ *
+ * @private
+ */
+const isInitialized = () => configInitialized;
+
 module.exports = {
   mergeConfig,
   init,
@@ -141,6 +148,7 @@ module.exports = {
   getAll,
   set,
   reset,
+  isInitialized,
   defaultConfig,
 };
 

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -127,7 +127,6 @@ const processLogData = flow([filterLogData, prettyPrint]);
  * @param {*} message Log message
  *
  * @returns {string} Formatted message
- *
  * @private
  */
 const formatMessage = message => (isJSON(message) ? prettyPrint(redactSecrets(message)) : message);
@@ -136,10 +135,12 @@ const formatMessage = message => (isJSON(message) ? prettyPrint(redactSecrets(me
  * Get Winston log level based on SDK configuration.
  *
  * @returns {string} Log level
- *
  * @private
  */
 const getLogLevel = () => {
+  if (config.get('silent')) {
+    return 'crit';
+  }
   if (config.get('verbose')) {
     return 'verbose';
   }

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -172,12 +172,12 @@ const logFormat = ({ level, message = '', timestamp, meta = {} }) =>
     .trim();
 
 /**
- * Create Winston Console Transform
+ * Create Winston Console Transport
  *
- * @returns Winston Console Transform with configured log level
+ * @returns Winston Console Transport with configured log level
  * @private
  */
-const consoleTransform = () => new winston.transports.Console({ level: getLogLevel() });
+const consoleTransport = new winston.transports.Console({ level: getLogLevel() });
 
 /**
  * Winston logger configuration
@@ -187,7 +187,7 @@ const consoleTransform = () => new winston.transports.Console({ level: getLogLev
  */
 const logger = winston.createLogger({
   format: combine(timestampFormatter(), printf(logFormat)),
-  transports: [consoleTransform()],
+  transports: [consoleTransport],
 });
 
 /**
@@ -275,8 +275,7 @@ const completeLogSetup = () => {
   if (config.isInitialized()) {
     isLoggerSetupComplete = true;
 
-    logger.clear();
-    logger.add(consoleTransform());
+    consoleTransport.level = getLogLevel();
 
     // TODO: implement this logic as an event process (triggered by config.init) using the emitter module.
     // This is a breaking change, so it should be a part of the next major release.

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -138,9 +138,6 @@ const formatMessage = message => (isJSON(message) ? prettyPrint(redactSecrets(me
  * @private
  */
 const getLogLevel = () => {
-  if (config.get('silent')) {
-    return 'crit';
-  }
   if (config.get('verbose')) {
     return 'verbose';
   }
@@ -177,7 +174,7 @@ const logFormat = ({ level, message = '', timestamp, meta = {} }) =>
  * @returns Winston Console Transport with configured log level
  * @private
  */
-const consoleTransport = new winston.transports.Console({ level: getLogLevel() });
+const consoleTransport = new winston.transports.Console({ level: getLogLevel(), silent: config.get('silent') });
 
 /**
  * Winston logger configuration
@@ -276,6 +273,7 @@ const completeLogSetup = () => {
     isLoggerSetupComplete = true;
 
     consoleTransport.level = getLogLevel();
+    consoleTransport.silent = config.get('silent');
 
     // TODO: implement this logic as an event process (triggered by config.init) using the emitter module.
     // This is a breaking change, so it should be a part of the next major release.

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -287,6 +287,17 @@ const completeLogSetup = () => {
 };
 
 /**
+ * Reset logger setup.
+ *
+ * Used for testing purposes.
+ *
+ * @private
+ */
+const resetLoggerSetup = () => {
+  isLoggerSetupComplete = false;
+};
+
+/**
  * Takes a message string and a data object, returning a string with redacted and filtered data.
  *
  * @param {string} message The string template with placeholders.
@@ -346,4 +357,5 @@ module.exports = {
   REDACTED_MESSAGE,
   filterLogData,
   processLogData,
+  resetLoggerSetup,
 };

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -171,6 +171,14 @@ const logFormat = ({ level, message = '', timestamp, meta = {} }) =>
     .trim();
 
 /**
+ * Create Winston Console Transform
+ *
+ * @returns Winston Console Transform with configured log level
+ * @private
+ */
+const consoleTransform = () => new winston.transports.Console({ level: getLogLevel() });
+
+/**
  * Winston logger configuration
  *
  * @type {winston.Logger}
@@ -178,7 +186,7 @@ const logFormat = ({ level, message = '', timestamp, meta = {} }) =>
  */
 const logger = winston.createLogger({
   format: combine(timestampFormatter(), printf(logFormat)),
-  transports: [new winston.transports.Console({ level: getLogLevel() })],
+  transports: [consoleTransform()],
 });
 
 /**
@@ -225,12 +233,12 @@ const removeFileLogger = () => {
 };
 
 /**
- * Toggle log-to-file configuration for `logger`.
+ * Set/Reset log-to-file configuration for `logger`.
  *
  * @see {@link logger} for more information.
  * @private
  */
-const toggleFileLogger = () => {
+const setFileLogger = () => {
   if (isFileLoggerEnabled) {
     removeFileLogger();
   }
@@ -249,8 +257,33 @@ function setLogFilePath(path) {
     config.set('logFilePath', path);
   }
 
-  toggleFileLogger();
+  setFileLogger();
 }
+
+/** Flag for whether logger setup has completed (following config module init) */
+let isLoggerSetupComplete = false;
+
+/**
+ * Update logger setup with Console Transform and optional File Transform.
+ *
+ * Used following library config initialization to adjust logging, if necessary.
+ *
+ * @private
+ */
+const completeLogSetup = () => {
+  if (config.isInitialized()) {
+    isLoggerSetupComplete = true;
+
+    logger.clear();
+    logger.add(consoleTransform());
+
+    // TODO: implement this logic as an event process (triggered by config.init) using the emitter module.
+    // This is a breaking change, so it should be a part of the next major release.
+    if (config.get('logToFile')) {
+      setLogFilePath();
+    }
+  }
+};
 
 /**
  * Takes a message string and a data object, returning a string with redacted and filtered data.
@@ -286,6 +319,10 @@ const mergeMessageAndData = (message, data) => {
  * (if the {@link module:config} option `verbose` is `true`).
  */
 function log(message, { level = 'info', meta = {}, data = {} } = {}) {
+  if (!isLoggerSetupComplete) {
+    completeLogSetup();
+  }
+
   if (message instanceof Error) {
     const error = message;
     message = `${error.message}\n${error.stack}`;
@@ -295,12 +332,6 @@ function log(message, { level = 'info', meta = {}, data = {} } = {}) {
   }
 
   return logger.log(level, { message, meta: config.get('verbose') && filterLogData(meta) });
-}
-
-// TODO: implement this logic as an event process (triggered by config.init) using the emitter module.
-// This is a breaking change, so it should be a part of the next major release.
-if (config.get('logToFile')) {
-  setLogFilePath();
 }
 
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6395,6 +6395,12 @@
         "globby": "^6.1.0"
       }
     },
+    "git-hooks-list": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/git-hooks-list/-/git-hooks-list-3.0.0.tgz",
+      "integrity": "sha512-XDfdemBGJIMAsHHOONHQxEH5dX2kCpE6MGZ1IsNvBuDPBZM3p4EAwAC7ygMjn/1/x+BJX0TK1ara1Zrh7JCFdQ==",
+      "dev": true
+    },
     "git-raw-commits": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.11.tgz",
@@ -11516,6 +11522,65 @@
       "dev": true,
       "requires": {
         "is-plain-obj": "^1.0.0"
+      }
+    },
+    "sort-object-keys": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sort-object-keys/-/sort-object-keys-1.1.3.tgz",
+      "integrity": "sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==",
+      "dev": true
+    },
+    "sort-package-json": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-2.1.0.tgz",
+      "integrity": "sha512-M5ctkdnn7znAkoVQJ0Y+PHDUieyXMhydPyW7r2J9ZM0Iwc3BTyEf5cmoSRfHNo07FEvzWwnphcP7GlrAX164UQ==",
+      "dev": true,
+      "requires": {
+        "detect-indent": "^7.0.1",
+        "detect-newline": "^4.0.0",
+        "git-hooks-list": "^3.0.0",
+        "globby": "^13.1.2",
+        "is-plain-obj": "^4.1.0",
+        "sort-object-keys": "^1.1.3"
+      },
+      "dependencies": {
+        "detect-indent": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-7.0.1.tgz",
+          "integrity": "sha512-Mc7QhQ8s+cLrnUfU/Ji94vG/r8M26m8f++vyres4ZoojaRDpZ1eSIh/EpzLNwlWuvzSZ3UbDFspjFvTDXe6e/g==",
+          "dev": true
+        },
+        "detect-newline": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-4.0.0.tgz",
+          "integrity": "sha512-1aXUEPdfGdzVPFpzGJJNgq9o81bGg1s09uxTWsqBlo9PI332uyJRQq13+LK/UN4JfxJbFdCXonUFQ9R/p7yCtw==",
+          "dev": true
+        },
+        "globby": {
+          "version": "13.1.2",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.2.tgz",
+          "integrity": "sha512-LKSDZXToac40u8Q1PQtZihbNdTYSNMuWe+K5l+oa6KgDzSvVrHXlJy40hUP522RjAIoNLJYBJi7ow+rbFpIhHQ==",
+          "dev": true,
+          "requires": {
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.2.11",
+            "ignore": "^5.2.0",
+            "merge2": "^1.4.1",
+            "slash": "^4.0.0"
+          }
+        },
+        "is-plain-obj": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+          "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+          "dev": true
+        },
+        "slash": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+          "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+          "dev": true
+        }
       }
     },
     "source-map": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,19 @@
 {
   "name": "@rewardops/sdk-node",
   "version": "2.5.3",
-  "engines": {
-    "node": ">=10"
-  },
   "description": "Node.js SDK for the RewardOps API",
-  "author": "RewardOps",
+  "keywords": [
+    "RewardOps",
+    "rewards",
+    "API"
+  ],
+  "homepage": "https://rewardops.github.io/rewardops-sdk-node/",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:rewardops/rewardops-sdk-node.git"
+  },
   "license": "MIT",
+  "author": "RewardOps",
   "contributors": [
     {
       "name": "Michael Yeung",
@@ -29,27 +36,40 @@
       "email": "alex.cheng@rewardops.com"
     }
   ],
-  "repository": {
-    "type": "git",
-    "url": "git@github.com:rewardops/rewardops-sdk-node.git"
-  },
-  "homepage": "https://rewardops.github.io/rewardops-sdk-node/",
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {
     "build:docs": "jsdoc -c jsdoc.json lib/rewardops.js",
     "lint": "eslint --cache --ignore-path .gitignore .",
-    "test": "jest",
+    "prepare": "husky install",
     "prepublish:docs": "npm run build:docs",
     "publish:docs": "gh-pages -d docs",
     "release": "standard-version",
-    "prepare": "husky install"
+    "test": "jest"
   },
-  "keywords": [
-    "RewardOps",
-    "rewards",
-    "API"
-  ],
+  "lint-staged": {
+    "*.{js,md,json,yaml}": [
+      "prettier --write",
+      "git add"
+    ],
+    "*.js": [
+      "eslint --fix",
+      "git add"
+    ],
+    "package.json": [
+      "sort-package-json"
+    ]
+  },
+  "dependencies": {
+    "axios": "^0.21.4",
+    "lodash": "^4.17.21",
+    "redact-secrets": "^1.0.0",
+    "redactyl.js": "^1.4.3",
+    "request": "^2.88.2",
+    "serialize-error": "^8.1.0",
+    "winston": "^3.6.0",
+    "yup": "^0.29.3"
+  },
   "devDependencies": {
     "@commitlint/cli": "^16.2.1",
     "@commitlint/config-conventional": "^16.2.1",
@@ -73,26 +93,10 @@
     "nock": "^9.6.1",
     "prettier": "^1.19.1",
     "sinon": "^1.17.7",
+    "sort-package-json": "^2.1.0",
     "standard-version": "^9.3.2"
   },
-  "dependencies": {
-    "axios": "^0.21.4",
-    "lodash": "^4.17.21",
-    "redact-secrets": "^1.0.0",
-    "redactyl.js": "^1.4.3",
-    "request": "^2.88.2",
-    "serialize-error": "^8.1.0",
-    "winston": "^3.6.0",
-    "yup": "^0.29.3"
-  },
-  "lint-staged": {
-    "*.{js,md,json,yaml}": [
-      "prettier --write",
-      "git add"
-    ],
-    "*.js": [
-      "eslint --fix",
-      "git add"
-    ]
+  "engines": {
+    "node": ">=10"
   }
 }

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -16,6 +16,7 @@ const OPTIONAL_PROPS = [
   'timeout',
   'verbose',
   'quiet',
+  'silent',
 ];
 
 describe('config', () => {

--- a/test/test-helpers/mock-config.js
+++ b/test/test-helpers/mock-config.js
@@ -29,10 +29,11 @@ const mockConfig = ({
   clientSecret = getTestAccessToken(),
   logToFile = false,
   timeout = 20000,
-  verbose = true,
-  quiet = true,
   supportedLocales = undefined,
   logFilePath = faker.system.filePath(),
+  silent = false,
+  verbose = false,
+  quiet = false,
 } = {}) => ({
   apiServerUrl,
   apiVersion,
@@ -41,9 +42,10 @@ const mockConfig = ({
   clientSecret,
   logToFile,
   timeout,
-  verbose,
   supportedLocales,
   logFilePath,
+  silent,
+  verbose,
   quiet,
 });
 

--- a/test/utils/logger.test.js
+++ b/test/utils/logger.test.js
@@ -145,7 +145,8 @@ describe('#getLogLevel', () => {
       ${false} | ${true}  | ${false} | ${'verbose'}
       ${false} | ${false} | ${true}  | ${'warn'}
       ${false} | ${true}  | ${true}  | ${'verbose'}
-      ${true}  | ${true}  | ${true}  | ${'crit'}
+      ${true}  | ${true}  | ${true}  | ${'verbose'}
+      ${true}  | ${false} | ${true}  | ${'warn'}
     `(
       `returns '$expected' when 'silent' is $silent, 'verbose' is $verbose, and 'quiet' is $quiet`,
       ({ silent, verbose, quiet, expected }) => {

--- a/test/utils/logger.test.js
+++ b/test/utils/logger.test.js
@@ -430,5 +430,14 @@ describe('#log', () => {
 
       expect(mockConsole.log).not.toHaveBeenCalledWith(expect.stringContaining('testLog'));
     });
+
+    test.each(['error', 'warn', 'info', 'debug'])('%s message is NOT logged when `silent` is `true`', level => {
+      config.init(mockConfig({ silent: true }));
+
+      log('silent testLog', { level });
+
+      const consoleFn = level === 'error' || level === 'warn' ? mockConsole[level] : mockConsole.log;
+      expect(consoleFn).not.toHaveBeenCalledWith(expect.stringContaining('testLog'));
+    });
   });
 });

--- a/test/utils/logger.test.js
+++ b/test/utils/logger.test.js
@@ -151,17 +151,22 @@ describe('#getLogLevel', () => {
 
   describe('config settings', () => {
     test.each`
-      verbose  | quiet    | expected
-      ${false} | ${false} | ${'info'}
-      ${true}  | ${false} | ${'verbose'}
-      ${false} | ${true}  | ${'warn'}
-      ${true}  | ${true}  | ${'verbose'}
-    `(`returns '$expected' when 'verbose' is $verbose and 'quiet' is $quiet`, ({ verbose, quiet, expected }) => {
-      config.set('verbose', verbose);
-      config.set('quiet', quiet);
+      silent   | verbose  | quiet    | expected
+      ${false} | ${false} | ${false} | ${'info'}
+      ${false} | ${true}  | ${false} | ${'verbose'}
+      ${false} | ${false} | ${true}  | ${'warn'}
+      ${false} | ${true}  | ${true}  | ${'verbose'}
+      ${true}  | ${true}  | ${true}  | ${'crit'}
+    `(
+      `returns '$expected' when 'silent' is $silent, 'verbose' is $verbose, and 'quiet' is $quiet`,
+      ({ silent, verbose, quiet, expected }) => {
+        config.set('silent', silent);
+        config.set('verbose', verbose);
+        config.set('quiet', quiet);
 
-      expect(getLogLevel()).toEqual(expected);
-    });
+        expect(getLogLevel()).toEqual(expected);
+      }
+    );
   });
 });
 

--- a/test/utils/logger.test.js
+++ b/test/utils/logger.test.js
@@ -1,3 +1,4 @@
+// NOTE: Logger exports are imported using `jest.requireActual` as they are globally mocked
 const mockDate = require('mockdate');
 const faker = require('faker');
 const _ = require('lodash');
@@ -6,17 +7,7 @@ const config = require('../../lib/config');
 const { LOG_PREFIX } = require('../../lib/constants');
 const { mockConfig } = require('../test-helpers/mock-config');
 
-const {
-  formatMessage,
-  getLogLevel,
-  log,
-  logFormat,
-  prettyPrint,
-  redactSecrets,
-  REDACTED_MESSAGE,
-  filterLogData,
-  processLogData,
-} = jest.requireActual('../../lib/utils/logger');
+const { prettyPrint, REDACTED_MESSAGE } = jest.requireActual('../../lib/utils/logger');
 
 // test setup
 const timestamp = Date.now();
@@ -113,6 +104,8 @@ describe('#prettyPrint', () => {
 });
 
 describe('#redactSecrets', () => {
+  const { redactSecrets } = jest.requireActual('../../lib/utils/logger');
+
   it.each`
     input                                          | secretPropPath
     ${{ secret: 'sauce' }}                         | ${['secret']}
@@ -126,6 +119,8 @@ describe('#redactSecrets', () => {
 });
 
 describe('#formatMessage', () => {
+  const { formatMessage } = jest.requireActual('../../lib/utils/logger');
+
   it.each`
     input                         | expectedSubstring
     ${{}}                         | ${'{}'}
@@ -145,6 +140,8 @@ describe('#formatMessage', () => {
 });
 
 describe('#getLogLevel', () => {
+  const { getLogLevel } = jest.requireActual('../../lib/utils/logger');
+
   beforeEach(() => {
     jest.spyOn(console, 'warn').mockImplementation(() => {});
   });
@@ -171,6 +168,8 @@ describe('#getLogLevel', () => {
 });
 
 describe('#filterLogData', () => {
+  const { filterLogData } = jest.requireActual('../../lib/utils/logger');
+
   it.each([[], null, undefined, 1, 'foo'])('returns %p since it is not an object', input => {
     expect(filterLogData(input)).toBe(input);
   });
@@ -226,6 +225,8 @@ describe('#filterLogData', () => {
 });
 
 describe('#processLogData', () => {
+  const { processLogData } = jest.requireActual('../../lib/utils/logger');
+
   it('should filter then pretty print the log data', () => {
     const output = processLogData(PIIData);
 
@@ -234,6 +235,8 @@ describe('#processLogData', () => {
 });
 
 describe('#logFormat', () => {
+  const { logFormat } = jest.requireActual('../../lib/utils/logger');
+
   const mockTimestamp = new Date().toISOString();
   const mockLogLevel = faker.random.arrayElement(['error', 'warn', 'info', 'debug', 'verbose']);
   const mockMessage = faker.lorem.sentence();
@@ -310,6 +313,8 @@ describe('#logFormat', () => {
 });
 
 describe('#log', () => {
+  const { log } = jest.requireActual('../../lib/utils/logger');
+
   beforeEach(() => {
     // eslint-disable-next-line no-global-assign
     console = mockConsole;
@@ -387,8 +392,15 @@ describe('#log', () => {
   });
 
   describe('config settings', () => {
-    test('options.meta is present in the log when `verbose` is true', () => {
+    beforeEach(() => {
       config.reset();
+    });
+
+    afterEach(() => {
+      config.reset();
+    });
+
+    test('options.meta is present in the log when `verbose` is true', () => {
       config.init(mockConfig({ verbose: true }));
 
       log('testLog', { meta: { foo: 'bar' } });
@@ -397,7 +409,6 @@ describe('#log', () => {
     });
 
     test('options.meta is not present in the log when `verbose` is `false`', () => {
-      config.reset();
       config.init(mockConfig({ verbose: false }));
 
       log('testLog', { meta: { foo: 'bar' } });
@@ -406,7 +417,6 @@ describe('#log', () => {
     });
 
     test('message is logged when `quiet` is true', () => {
-      config.reset();
       config.init(mockConfig({ quiet: true }));
 
       log('testLog');


### PR DESCRIPTION
## Description

Completes [MX-3005](https://rewardops.atlassian.net/browse/MX-3005).

Turns out that, due to a logic error, log-related config settings never altered library logging (e.g., setting the `verbose` option to `true`), and our tests were improperly written to cover this functionality.

Essentially, the library defaults were always being used when it comes to setting the configured log level; i.e. options set in `config.init` were ignored.

This PR fixes that and also adds a new `silent` config setting that suppresses all console logging, which is useful for testing purposes (esp. when RewardOps XHRs are made via a mocking library, such as https://github.com/mswjs/msw, through an app).

Bonus:

- add `package.json` auto-sort during `pre-commit` hook

## Testing instructions

- Run the tests!
- If you're feeling _really_ ambitious, you can copy-paste the library into a `node_modules` directory of an app using this dependency and play around with it.