### PR TITLE
[rewardops-sdk]: MX-3397 personalization resources

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest: personalization.test",
+      //"env": { "NODE_ENV": "test" },
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": ["personalization.test", "--config", "jest.config.js"],
+      "console": "integratedTerminal",
+      "windows": {
+        "program": "${workspaceFolder}/node_modules/jest/bin/jest"
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -167,6 +167,11 @@ npm link
 npm link @rewardops/sdk-node
 ```
 
+## Running Locally
+
+Right now there is no way for this to run locally, because this project does not act as a server or something similar.
+One way to test your changes are correct are not are writing unit tests in their respective folders, for example if you added a new resource, you can add a test inside `test / resources / ${api_version_resource uses} / ${resouce}.js` file. You can then debug that in `VS Code`, the configuration is already added, you just have to update the first argument of the `args` array inside `launch.json`, change that to the name of the test file that you want to run and it will start debug with real values just to verify, after that you can mock the values when commiting your code.
+
 **NOTE** There is no hot reloading, if you make code changes to the SDK, you will have to re-run step 2 for you changes to appear in your app. Running `yarn install` will also remove the symlink.
 
 To run the library test suite:

--- a/index.d.ts
+++ b/index.d.ts
@@ -140,6 +140,25 @@ declare module '@rewardops/sdk-node' {
     };
   };
 
+  enum Segment {
+    status = 'status',
+    nonStatus = 'non_status'
+  }
+
+  interface GenericRegisterMemberTagsParams {
+    foreign_id: string;
+    member_tags: string;
+    segment: Segment;
+  }
+
+  interface RegisterMemberTagsParams extends GenericRegisterMemberTagsParams {
+    program_code: string;
+  }
+
+  interface RegisterMemberTagsResponse extends GenericRegisterMemberTagsParams {
+    id: string;
+  }
+
   interface Program {
     details: any;
     items: {
@@ -201,6 +220,9 @@ declare module '@rewardops/sdk-node' {
     coupons: {
       postValidate: (params: PostValidateParams, callback: RequestCallback) => PostValidateResponse;
     };
+    personalization: {
+      registerMemberTags: (member: RegisterMemberTagsParams) => RegisterMemberTagsResponse;
+    }
   }
 
   const program = (id: number, code?: string) => ({} as Program);

--- a/index.d.ts
+++ b/index.d.ts
@@ -221,7 +221,7 @@ declare module '@rewardops/sdk-node' {
       postValidate: (params: PostValidateParams, callback: RequestCallback) => PostValidateResponse;
     };
     personalization: {
-      registerMemberTags: (member: RegisterMemberTagsParams) => RegisterMemberTagsResponse;
+      registerMemberTags: (member: RegisterMemberTagsParams, callback: RequestCallback) => RegisterMemberTagsResponse;
     }
   }
 

--- a/lib/resources/personalization.js
+++ b/lib/resources/personalization.js
@@ -21,8 +21,8 @@ function Personalization(programCode) {
   /**
    *
    * @param {*} member consists of foreign_id, segment, member_tags, program_code
-   * @param callback
-   * @returns {string} memberUUID
+   * @param callback callback function which will be called from client once done
+   * @returns {void}
    */
   const registerMemberTags = async (member, callback) => {
     try {
@@ -34,7 +34,7 @@ function Personalization(programCode) {
       const {
         data: { result },
       } = await piiServerClient.post(url, member);
-      callback(null, null, result);
+      callback(undefined, undefined, result);
     } catch (error) {
       log('API Error: {error}', { level: 'error', data: { error } });
       callback(error, undefined, undefined);

--- a/lib/resources/personalization.js
+++ b/lib/resources/personalization.js
@@ -5,7 +5,6 @@
  * @copyright 2015–2023 RewardOps Inc.
  */
 const axios = require('axios');
-const { get } = require('lodash');
 
 const config = require('../config');
 const { setPiiToken } = require('../utils/axios-helpers');
@@ -22,9 +21,10 @@ function Personalization(programCode) {
   /**
    *
    * @param {*} member consists of foreign_id, segment, member_tags, program_code
+   * @param callback
    * @returns {string} memberUUID
    */
-  const registerMemberTags = async member => {
+  const registerMemberTags = async (member, callback) => {
     try {
       await setPiiToken(piiServerClient);
       const url = `${config.get('piiServerUrl')}/api/v5/programs/${programCode}/members`;
@@ -34,11 +34,10 @@ function Personalization(programCode) {
       const {
         data: { result },
       } = await piiServerClient.post(url, member);
-      return result;
+      callback(null, null, result);
     } catch (error) {
       log('API Error: {error}', { level: 'error', data: { error } });
-      // eslint-disable-next-line no-throw-literal
-      throw { error: get(error, 'response', error) };
+      callback(error, undefined, undefined);
     }
   };
 

--- a/lib/resources/personalization.js
+++ b/lib/resources/personalization.js
@@ -1,0 +1,48 @@
+/**
+ * Personalization resources
+ *
+ * @module resources/order-recipients
+ * @copyright 2015–2023 RewardOps Inc.
+ */
+const axios = require('axios');
+const { get } = require('lodash');
+
+const config = require('../config');
+const { setPiiToken } = require('../utils/axios-helpers');
+const { log } = require('../utils/logger');
+
+const piiServerClient = axios.create();
+
+/**
+ *
+ * @param {string} programCode pangea program code
+ * @returns {*} registerMemberTags function
+ */
+function Personalization(programCode) {
+  /**
+   *
+   * @param {*} member consists of foreign_id, segment, member_tags, program_code
+   * @returns {string} memberUUID
+   */
+  const registerMemberTags = async member => {
+    try {
+      await setPiiToken(piiServerClient);
+      const url = `${config.get('piiServerUrl')}/api/v5/programs/${programCode}/members`;
+
+      log('Request: POST {url}\nPayload: {member}', { data: { url, member } });
+
+      const {
+        data: { result },
+      } = await piiServerClient.post(url, member);
+      return result;
+    } catch (error) {
+      log('API Error: {error}', { level: 'error', data: { error } });
+      // eslint-disable-next-line no-throw-literal
+      throw { error: get(error, 'response', error) };
+    }
+  };
+
+  return { registerMemberTags };
+}
+
+module.exports = Personalization;

--- a/lib/resources/programs.js
+++ b/lib/resources/programs.js
@@ -10,6 +10,7 @@ const customCategories = require('./custom-categories');
 const rewards = require('./rewards');
 const { contextInstance, contextType } = require('../context');
 const { coupons } = require('./coupons');
+const Personalization = require('./personalization');
 
 /**
  * A program-specific context type object with `getAll` and `get` methods.
@@ -73,6 +74,7 @@ const program = (id, code) => {
     customCategories: customCategories(id),
     rewards: rewards(id),
     coupons,
+    personalization: Personalization(code),
     ...contextInstance('programs', id, code),
   };
 };

--- a/test/resources/v5/personalization.test.js
+++ b/test/resources/v5/personalization.test.js
@@ -65,7 +65,7 @@ describe('v5', () => {
               done();
             });
         });
-      }, 20000); // sometimes the pii server takes time to respond
+      });
     });
   });
 });

--- a/test/resources/v5/personalization.test.js
+++ b/test/resources/v5/personalization.test.js
@@ -48,14 +48,15 @@ describe('v5', () => {
           });
 
         return new Promise(done => {
-          program.personalization
-            .registerMemberTags({
+          program.personalization.registerMemberTags(
+            {
               foreign_id: '114215767',
               segment: 'status',
               member_tags: 'stb,ubr',
               program_code: programCode,
-            })
-            .then(data => {
+            },
+            (err, _, data) => {
+              expect(err).toBe(undefined);
               expect(typeof data).toBe('object');
               expect(data.id).toBeDefined(); // id is memberUUID
               expect(data.foreign_id).toBeDefined();
@@ -63,7 +64,8 @@ describe('v5', () => {
               expect(apiCall.isDone()).toEqual(true);
 
               done();
-            });
+            }
+          );
         });
       });
     });

--- a/test/resources/v5/personalization.test.js
+++ b/test/resources/v5/personalization.test.js
@@ -1,0 +1,48 @@
+const RO = require('../../..');
+const { mockConfig } = require('../../test-helpers/mock-config');
+const { CLIENT_ID, CLIENT_SECRET } = require('../../fixtures/v5/credentials');
+
+// NOTE: for this test to work we have to use real CLIENT_ID and CLIENT_SECRET values instead of mock ones
+RO.config.init(
+  mockConfig({
+    apiVersion: 'v5',
+    piiServerUrl: 'https://api-qa.ca.rewardops.io',
+    clientId: CLIENT_ID,
+    clientSecret: CLIENT_SECRET,
+    supportedLocales: ['en-CA'],
+  })
+);
+
+describe('v5', () => {
+  afterAll(() => {
+    RO.config.reset();
+  });
+
+  describe('personalization', () => {
+    const id = 384;
+    const programCode = 'aeroplan_program';
+    const program = RO.program(id, programCode);
+
+    describe('registerMemberTags()', () => {
+      it('should register member tags and return member UUID', () => {
+        return new Promise(done => {
+          program.personalization
+            .registerMemberTags({
+              foreign_id: '114215767',
+              segment: 'status',
+              member_tags: 'stb,ubr',
+              program_code: programCode,
+            })
+            .then(data => {
+              expect(typeof data).toBe('object');
+              expect(data.id).toBeDefined(); // id is memberUUID
+              expect(data.foreign_id).toBeDefined();
+              expect(data.member_tags).toBeDefined();
+
+              done();
+            });
+        });
+      }, 20000); // sometimes the pii server takes time to respond
+    });
+  });
+});


### PR DESCRIPTION
## Description
- [MX-3397](https://rewardops.atlassian.net/browse/MX-3397)
- Adds a new resource for personalization, added a new endpoint for registering `member_tags`.

[MX-3397]: https://rewardops.atlassian.net/browse/MX-3397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ