### PR TITLE
[rewardops-sdk]: MX-3500: Call the Favourite/Wishlist API on the SDK to create or delete a member's list

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,10 +7,10 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Jest: personalization.test",
+      "name": "Jest: members.test",
       //"env": { "NODE_ENV": "test" },
       "program": "${workspaceFolder}/node_modules/.bin/jest",
-      "args": ["personalization.test", "--config", "jest.config.js"],
+      "args": ["members.test", "--config", "jest.config.js"],
       "console": "integratedTerminal",
       "windows": {
         "program": "${workspaceFolder}/node_modules/jest/bin/jest"

--- a/index.d.ts
+++ b/index.d.ts
@@ -220,6 +220,7 @@ declare module '@rewardops/sdk-node' {
     coupons: {
       postValidate: (params: PostValidateParams, callback: RequestCallback) => PostValidateResponse;
     };
+    members: (memberUUID: string) => any;
     personalization: {
       registerMemberTags: (member: RegisterMemberTagsParams, callback: RequestCallback) => RegisterMemberTagsResponse;
     }

--- a/lib/api.js
+++ b/lib/api.js
@@ -145,6 +145,7 @@ const HTTP_METHODS = {
   GET: 'GET',
   POST: 'POST',
   PATCH: 'PATCH',
+  DELETE: 'DELETE',
 };
 
 /**
@@ -154,6 +155,7 @@ const HTTP_METHODS = {
  * @property {module:api~apiCall} get `GET` API call method
  * @property {module:api~apiCall} post `POST` API call method
  * @property {module:api~apiCall} patch `PATCH` API call method
+ * @property {module:api~apiCall} delete `DELETE` API call method
  *
  * @see {@link HTTP_METHODS} for more information
  */

--- a/lib/resources/members.js
+++ b/lib/resources/members.js
@@ -1,0 +1,166 @@
+/**
+ * Favourites(retaillers) resources
+ *
+ * @module resources/members
+ * @copyright 2015–2023 RewardOps Inc.
+ */
+
+const { isEmpty } = require('lodash');
+const config = require('../config');
+const api = require('../api');
+const { log } = require('../utils/logger');
+
+/**
+ *
+ */
+function apiConfig() {
+  return {
+    ...config.getAll(),
+    apiVersion: 'v5',
+  };
+}
+
+/**
+ * @param path
+ * @param params
+ */
+function requestOptions(path, params = undefined) {
+  const options = {
+    path,
+    config: apiConfig(),
+  };
+
+  if (!isEmpty(params)) {
+    options.params = params;
+  }
+
+  return options;
+}
+
+/**
+ *
+ * @param {string} programCode pangea program code
+ * @param {string} memberUUID PII identificator
+ * @returns {*} function
+ * @protected
+ */
+const addToFavourites = (programCode, memberUUID) => {
+  /**
+   *
+   * @param {object} params
+   * @param {module:api~requestCallback} callback Callback that handles the response
+   */
+  return function addNewFavorite(params, callback) {
+    if (typeof params !== 'object' || isEmpty(params)) {
+      if (arguments.length === 1 && typeof params === 'function') {
+        callback = params;
+      }
+
+      callback(new Error('A params object is required'));
+
+      return;
+    }
+
+    try {
+      const reqPath = `/programs/${programCode}/members/${memberUUID}/favourites`;
+      const options = requestOptions(reqPath, params);
+
+      api.post(options, callback);
+    } catch (error) {
+      log('API Error: {error}', { level: 'error', data: { error } });
+      callback(error);
+    }
+  };
+};
+
+/**
+ *
+ * @param {string} programCode pangea program code
+ * @param {string} memberUUID PII identificator
+ * @returns {*} function
+ */
+const removeFromFavourites = (programCode, memberUUID) => {
+  return (itemOrderCode, callback) => {
+    try {
+      const reqPath = `/programs/${programCode}/members/${memberUUID}/favourites/${itemOrderCode}`;
+      const options = requestOptions(reqPath);
+
+      api.delete(options, callback);
+    } catch (error) {
+      log('API Error: {error}', { level: 'error', data: { error } });
+      callback(error);
+    }
+  };
+};
+
+/**
+ *
+ * @param {string} programCode pangea program code
+ * @param {string} memberUUID PII identificator
+ * @returns {*} function
+ */
+const addToWishlist = (programCode, memberUUID) => {
+  return function addNewWish(params, callback) {
+    if (typeof params !== 'object' || isEmpty(params)) {
+      if (arguments.length === 1 && typeof params === 'function') {
+        callback = params;
+      }
+
+      callback(new Error('A params object is required'));
+
+      return;
+    }
+
+    try {
+      const reqPath = `/programs/${programCode}/members/${memberUUID}/wishlist`;
+      const options = requestOptions(reqPath, params);
+
+      api.post(options, callback);
+    } catch (error) {
+      log('API Error: {error}', { level: 'error', data: { error } });
+      callback(error);
+    }
+  };
+};
+
+/**
+ *
+ * @param {string} programCode pangea program code
+ * @param {string} memberUUID PII identificator
+ * @returns {*} function
+ */
+const removeFromWishlist = (programCode, memberUUID) => {
+  return (itemOrderCode, callback) => {
+    try {
+      const reqPath = `/programs/${programCode}/members/${memberUUID}/wishlist/${itemOrderCode}`;
+      const options = requestOptions(reqPath);
+
+      api.delete(options, callback);
+    } catch (error) {
+      log('API Error: {error}', { level: 'error', data: { error } });
+      callback(error);
+    }
+  };
+};
+
+/**
+ *
+ * @param {string} programCode pangea program code
+ * @returns {*} memberFactory function
+ */
+const memberFactory = programCode => {
+  return memberUUID => ({
+    programCode,
+    memberUUID,
+    favourites: {
+      addItem: addToFavourites(programCode, memberUUID),
+      removeItem: removeFromFavourites(programCode, memberUUID),
+    },
+    wishlist: {
+      addItem: addToWishlist(programCode, memberUUID),
+      removeItem: removeFromWishlist(programCode, memberUUID),
+    },
+  });
+};
+
+module.exports = memberFactory;

--- a/lib/resources/members.js
+++ b/lib/resources/members.js
@@ -80,10 +80,10 @@ const addToFavourites = (programCode, memberUUID) => {
  * @returns {*} function
  */
 const removeFromFavourites = (programCode, memberUUID) => {
-  return (itemOrderCode, callback) => {
+  return (params, callback) => {
     try {
-      const reqPath = `/programs/${programCode}/members/${memberUUID}/favourites/${itemOrderCode}`;
-      const options = requestOptions(reqPath);
+      const reqPath = `/programs/${programCode}/members/${memberUUID}/favourites`;
+      const options = requestOptions(reqPath, params);
 
       api.delete(options, callback);
     } catch (error) {
@@ -130,10 +130,10 @@ const addToWishlist = (programCode, memberUUID) => {
  * @returns {*} function
  */
 const removeFromWishlist = (programCode, memberUUID) => {
-  return (itemOrderCode, callback) => {
+  return (params, callback) => {
     try {
-      const reqPath = `/programs/${programCode}/members/${memberUUID}/wishlist/${itemOrderCode}`;
-      const options = requestOptions(reqPath);
+      const reqPath = `/programs/${programCode}/members/${memberUUID}/wishlist`;
+      const options = requestOptions(reqPath, params);
 
       api.delete(options, callback);
     } catch (error) {

--- a/lib/resources/programs.js
+++ b/lib/resources/programs.js
@@ -11,6 +11,7 @@ const rewards = require('./rewards');
 const { contextInstance, contextType } = require('../context');
 const { coupons } = require('./coupons');
 const Personalization = require('./personalization');
+const members = require('./members');
 
 /**
  * A program-specific context type object with `getAll` and `get` methods.
@@ -75,6 +76,7 @@ const program = (id, code) => {
     rewards: rewards(id),
     coupons,
     personalization: Personalization(code),
+    members: members(code),
     ...contextInstance('programs', id, code),
   };
 };

--- a/test/resources/v5/members.test.js
+++ b/test/resources/v5/members.test.js
@@ -1,0 +1,214 @@
+const nock = require('nock');
+const RO = require('../../..');
+const { mockConfig } = require('../../test-helpers/mock-config');
+const { generateBasicAuthToken } = require('../../../lib/utils/auth');
+const { CLIENT_ID, CLIENT_SECRET, ACCESS_TOKEN } = require('../../fixtures/v5/credentials');
+
+const mockCallBack = jest.fn();
+
+RO.config.init(
+  mockConfig({
+    apiVersion: 'v5',
+    piiServerUrl: null,
+    clientId: CLIENT_ID,
+    clientSecret: CLIENT_SECRET,
+  })
+);
+
+describe('v5', () => {
+  const memberUUID = 'a0bf0938-1a85-445d-a0bh-ebd23d35cb8s';
+
+  afterAll(() => {
+    RO.config.reset();
+  });
+
+  beforeAll(() => {
+    nock(RO.auth.getBaseUrl(), {
+      reqheaders: generateBasicAuthToken(CLIENT_ID, CLIENT_SECRET),
+    })
+      .post(RO.auth.getTokenPath(), {
+        grant_type: 'client_credentials',
+      })
+      .times(6)
+      .reply(200, {
+        created_at: Math.round(+new Date() / 1000),
+        expires_in: 7200,
+        access_token: ACCESS_TOKEN,
+      });
+  });
+
+  describe('members', () => {
+    const id = 384;
+    const programCode = 'aeroplan_program';
+    const program = RO.program(id, programCode);
+
+    describe('favourites', () => {
+      describe('#addItem()', () => {
+        const apiCall = nock(RO.urls.getApiBaseUrl(), {
+          reqHeaders: {
+            Authorization: `Bearer ${ACCESS_TOKEN}`,
+          },
+        })
+          .post(`/programs/${programCode}/members/${memberUUID}/favourites`)
+          .reply(200, {
+            status: 'OK',
+            result: [
+              {
+                siv_id: 1234,
+                item_order_token: 'bwtb5ngbkz01nnkkxhnvzh7se3fgs108',
+              },
+            ],
+          });
+
+        describe('Mark a retailer as favourite successfully', () => {
+          it('should add new favourite retailer', () => {
+            return new Promise(done => {
+              program.members(memberUUID).favourites.addItem(
+                {
+                  item_order_token: 'bwtb5ngbkz01nnkkxhnvzh7se3fgs108=',
+                  member_tags: 'tag1,tag2',
+                  segment: 'blue',
+                },
+                (error, data) => {
+                  expect(error).toBeNull();
+                  expect(typeof data).toBe('object');
+                  expect(Array.isArray(data)).toBe(true);
+                  expect(apiCall.isDone()).toEqual(true);
+
+                  done();
+                }
+              );
+            });
+          });
+        });
+
+        describe('error handling', () => {
+          it('responds with an error if the request params are empty', async () => {
+            const requestBody = {};
+
+            await program.members(memberUUID).favourites.addItem(requestBody, mockCallBack);
+
+            expect(mockCallBack).toHaveBeenCalledWith(new Error('A params object is required'));
+          });
+        });
+      });
+
+      describe('#removeItem()', () => {
+        const itemOrderCode = '0ca2cf32-59e8-473d-97ff-afc4e2670e37';
+
+        const apiCall = nock(RO.urls.getApiBaseUrl(), {
+          reqHeaders: {
+            Authorization: `Bearer ${ACCESS_TOKEN}`,
+          },
+        })
+          .delete(`/programs/${programCode}/members/${memberUUID}/favourites/${itemOrderCode}`)
+          .reply(200, {
+            status: 'OK',
+            result: [
+              {
+                siv_id: 1234,
+                item_order_token: 'bwtb5ngbkz01nnkkxhnvzh7se3fgs108',
+              },
+            ],
+          });
+
+        describe('Mark a retailer as unfavourite successfully', () => {
+          it('should remove a retailer from the favourite list', () => {
+            return new Promise(done => {
+              program.members(memberUUID).favourites.removeItem(itemOrderCode, (error, data) => {
+                expect(error).toBeNull();
+                expect(typeof data).toBe('object');
+                expect(Array.isArray(data)).toBe(true);
+                expect(apiCall.isDone()).toEqual(true);
+
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
+
+    describe('wishlist', () => {
+      describe('#addItem()', () => {
+        describe('Mark an item as favourite successfully', () => {
+          const apiCall = nock(RO.urls.getApiBaseUrl(), {
+            reqHeaders: {
+              Authorization: `Bearer ${ACCESS_TOKEN}`,
+            },
+          })
+            .post(`/programs/${programCode}/members/${memberUUID}/wishlist`)
+            .reply(200, {
+              status: 'OK',
+              result: [
+                {
+                  siv_id: 1234,
+                  item_order_token: 'bwtb5ngbkz01nnkkxhnvzh7se3fgs108',
+                },
+              ],
+            });
+
+          it('should create a new wishlist item', () => {
+            return new Promise(done => {
+              program.members(memberUUID).wishlist.addItem(
+                {
+                  item_order_token: 'bwtb5ngbkz01nnkkxhnvzh7se3fgs108=',
+                },
+                (error, data) => {
+                  expect(error).toBeNull();
+                  expect(typeof data).toBe('object');
+                  expect(Array.isArray(data)).toBe(true);
+                  expect(apiCall.isDone()).toEqual(true);
+
+                  done();
+                }
+              );
+            });
+          });
+        });
+
+        describe('error handling', () => {
+          it('responds with an error if the request params are empty', async () => {
+            const requestBody = {};
+
+            await program.members(memberUUID).wishlist.addItem(requestBody, mockCallBack);
+
+            expect(mockCallBack).toHaveBeenCalledWith(new Error('A params object is required'));
+          });
+        });
+      });
+
+      describe('removeItem()', () => {
+        it('should remove an item from wishlist', () => {
+          const itemOrderToken = '0ca2cf32-59e8-473d-97ff-afc4e2670e37';
+
+          const apiCall = nock(RO.urls.getApiBaseUrl(), {
+            reqHeaders: {
+              Authorization: `Bearer ${ACCESS_TOKEN}`,
+            },
+          })
+            .delete(`/programs/${programCode}/members/${memberUUID}/wishlist/${itemOrderToken}`)
+            .reply(200, {
+              status: 'OK',
+              result: [
+                {
+                  siv_id: 1234,
+                  item_order_token: 'bwtb5ngbkz01nnkkxhnvzh7se3fgs108',
+                },
+              ],
+            });
+
+          return new Promise(done => {
+            program.members(memberUUID).wishlist.removeItem(itemOrderToken, (error, data) => {
+              expect(error).toBeNull();
+              expect(typeof data).toBe('object');
+              expect(apiCall.isDone()).toEqual(true);
+
+              done();
+            });
+          });
+        });
+      });
+    });
+  });
+});

--- a/test/resources/v5/members.test.js
+++ b/test/resources/v5/members.test.js
@@ -94,14 +94,12 @@ describe('v5', () => {
       });
 
       describe('#removeItem()', () => {
-        const itemOrderCode = '0ca2cf32-59e8-473d-97ff-afc4e2670e37';
-
         const apiCall = nock(RO.urls.getApiBaseUrl(), {
           reqHeaders: {
             Authorization: `Bearer ${ACCESS_TOKEN}`,
           },
         })
-          .delete(`/programs/${programCode}/members/${memberUUID}/favourites/${itemOrderCode}`)
+          .delete(`/programs/${programCode}/members/${memberUUID}/favourites`)
           .reply(200, {
             status: 'OK',
             result: [
@@ -115,14 +113,19 @@ describe('v5', () => {
         describe('Mark a retailer as unfavourite successfully', () => {
           it('should remove a retailer from the favourite list', () => {
             return new Promise(done => {
-              program.members(memberUUID).favourites.removeItem(itemOrderCode, (error, data) => {
-                expect(error).toBeNull();
-                expect(typeof data).toBe('object');
-                expect(Array.isArray(data)).toBe(true);
-                expect(apiCall.isDone()).toEqual(true);
+              program.members(memberUUID).favourites.removeItem(
+                {
+                  item_order_token: 'bwtb5ngbkz01nnkkxhnvzh7se3fgs108=',
+                },
+                (error, data) => {
+                  expect(error).toBeNull();
+                  expect(typeof data).toBe('object');
+                  expect(Array.isArray(data)).toBe(true);
+                  expect(apiCall.isDone()).toEqual(true);
 
-                done();
-              });
+                  done();
+                }
+              );
             });
           });
         });
@@ -187,7 +190,7 @@ describe('v5', () => {
               Authorization: `Bearer ${ACCESS_TOKEN}`,
             },
           })
-            .delete(`/programs/${programCode}/members/${memberUUID}/wishlist/${itemOrderToken}`)
+            .delete(`/programs/${programCode}/members/${memberUUID}/wishlist`)
             .reply(200, {
               status: 'OK',
               result: [


### PR DESCRIPTION
https://rewardops.atlassian.net/browse/MX-3500

This PR extends sdk with the following methods:

- create a new favourite item
- remove an item from favourite list
- create a new wishlist item
- remove an item from wishlist list

**Example of a new method calling from SDK:** 
```
program.members(memberUUID).favourites.addItem({
    "item_order_token": "token",
    "member_tags": "STB",
    "segment": "status"
  }, () => {});
```
