### PR TITLE
MX-3892: Rename cart endpoint to cart summary (phase 1)

### DIFF
--- a/lib/resources/members.js
+++ b/lib/resources/members.js
@@ -175,7 +175,7 @@ const getShoppingCart = (memberUUID, programCode) => {
     }
 
     try {
-      const reqPath = `/programs/${programCode}/members/${memberUUID}/cart`;
+      const reqPath = `/programs/${programCode}/members/${memberUUID}/cart/summary`;
       const options = requestOptions(reqPath, params);
 
       api.get(options, callback);

--- a/test/resources/v5/members.test.js
+++ b/test/resources/v5/members.test.js
@@ -224,7 +224,7 @@ describe('v5', () => {
             Authorization: `Bearer ${ACCESS_TOKEN}`,
           },
         })
-          .get(`/programs/${programCode}/members/${memberUUID}/cart`)
+          .get(`/programs/${programCode}/members/${memberUUID}/cart/summary`)
           .query(params)
           .reply(200, {
             status: 'OK',


### PR DESCRIPTION
DON'T MERGE, WITHOUT DEPLOYING [PAN-9470](https://rewardops.atlassian.net/browse/PAN-9470)

1) Merge this branch into [feature/mx-3624-call-shopping-cart-api](https://github.com/rewardops/rewardops-sdk-node/tree/feature/mx-3624-call-shopping-cart-api)
2) Redeploy API-QA with https://rewardops.atlassian.net/browse/PAN-9470
3) Redeploy MX - just to pull the recent feature/mx-3624-call-shopping-cart-api

MX-3892: rename /cart endpoint call to /cart/summary (https://rewardops.atlassian.net/browse/MX-3892)

[PAN-9470]: https://rewardops.atlassian.net/browse/PAN-9470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ